### PR TITLE
Maintenance: Improve workflow runtime by installing torch+cpu upfront, to prevent large cuda libraries from beeing installed for running tests

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           python-version: 3.12
       - run: |
+          pip install torch>=2.0+cpu # Manually install torch+cpu because pyproject.toml does not support that ==> should prevent large cuda packages from being installed
           pip install ".[dev]"
 
       # Step 6: Run tests


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/build_and_release.yml` file. The change ensures that the correct version of the `torch` library is installed during the build process to prevent unnecessary large CUDA packages from being included.

* [`.github/workflows/build_and_release.yml`](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437R106): Added a command to manually install `torch>=2.0+cpu` to avoid installing large CUDA packages.