### PR TITLE
Fix SyntaxError in f-string within RemoveFlash Transform for Python 3.11 compatibility

### DIFF
--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -129,7 +129,7 @@ class RemoveFlash(ThermoTransform):
                 flash_end_idx = tdata.argmax(dim=2).max().item() + self.offset
             
             case _:
-                raise ValueError(f"Invalid method. Choose between {get_args(self.__init__.__annotations__["method"])}.")
+                raise ValueError(f"Invalid method. Choose between {get_args(self.__init__.__annotations__['method'])}.")
         
         # Check if the flash end is valid
         if flash_end_idx < 0 or flash_end_idx >= len(domain_values):


### PR DESCRIPTION
This pull request includes a small change to the `forward` method in the `src/pythermondt/transforms/preprocessing.py` file. The change corrects the string formatting for the error message by replacing double quotes with single quotes around the `method` key, to get python3.11 compatibility.