### PR TITLE
Fix not updating title in interactive data explorer

### DIFF
--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -144,8 +144,9 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self.current_frame = int(frame_idx)
             self.current_frame_data = self.tdata[self.current_frame].squeeze()
 
-            # Update image data
+            # Update image data and title
             self.frame_img.set_data(self.current_frame_data)
+            self.frame_ax.set_title(f'Frame {self.current_frame}')
 
             # Get the colorbar limits according to min/max of the current frame
             vmin = round(self.current_frame_data.min(), 8)


### PR DESCRIPTION
This pull request includes a modification to the `update_frame` method in the `visualization_ops.py` file. The change updates the image data and sets the title for the current frame.

* [`src/pythermondt/data/datacontainer/visualization_ops.py`](diffhunk://#diff-c60fc53eeb3fd4fc06ba351aefe9759dd43c8320e2288ee0c89264ca20112d5eL147-R149): Modified the `update_frame` method to set the title of the frame using `self.frame_ax.set_title(f'Frame {self.current_frame}')`.