### PR TITLE
Remove unused import of Unit from units module in __init__.py

### DIFF
--- a/src/pythermondt/data/__init__.py
+++ b/src/pythermondt/data/__init__.py
@@ -1,5 +1,5 @@
 from .datacontainer import DataContainer
 from .thermo_container import ThermoContainer
 from .thermo_dataset import ThermoDataset
-from .units import Units, Unit, generate_label, is_unit_info
+from .units import Units, generate_label, is_unit_info
 from .utils import random_split


### PR DESCRIPTION
This pull request includes a small change to the `src/pythermondt/data/__init__.py` file. The change removes the import of the `Unit` class from the `units` module. 

* [`src/pythermondt/data/__init__.py`](diffhunk://#diff-a37a55b8ed69b8e823ed8b07a2bdcef16c65bbaa8d2a5b525f394f1771a9d6b1L4-R4): Removed the import of the `Unit` class from the `units` module.