### PR TITLE
Fix raising an Invalid Path exception for Datasets that are directly located in the root path ('/Dataset')

### DIFF
--- a/src/pythermondt/data/datacontainer/serialization_ops.py
+++ b/src/pythermondt/data/datacontainer/serialization_ops.py
@@ -147,6 +147,7 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
         # validate the path using the utility function
         path = validate_path(path)
 
+        # Iterate over all attributes
         for key, value in attributes.items():
             # Convert JSON strings back to lists and dictionaries
             # Try to convert the string to a list or dictionary using the JSON format


### PR DESCRIPTION
This pull request involves changes to the `src/pythermondt/data/datacontainer/serialization_ops.py` file, focusing on the processing of datasets and attributes. The most important changes include the removal of path validation in the `_process_dataset` method and the addition of a comment in the `_process_attributes` method.

Changes to dataset processing:

* [`src/pythermondt/data/datacontainer/serialization_ops.py`](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L133-L135): Removed the path validation step in the `_process_dataset` method. This fixes raising an exception when a Dataset is located directly in the root path, because it tries to validate the path `/`. Path validation is not needed because the path is validated anyway when generating the key in `add_dataset`!

Changes to attribute processing:

* [`src/pythermondt/data/datacontainer/serialization_ops.py`](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03R150): Added a comment to iterate over all attributes in the `_process_attributes` method.