### PR TITLE
Fix test inconsistencies by reinstalling pythermondt after cache hits in GitHub Action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -36,18 +36,26 @@ jobs:
         env:
           pythonLocation: ${{ env.pythonLocation }}
 
-      # Step 4: Install Dependencies
+      # Step 4: Install dependencies if cache miss
       - if: steps.cache-pip.outputs.cache-hit != 'true'
-        name: Install Dependencies
+        name: Install dependencies
         run: |
+          echo "Cache miss, installing dependencies"
           pip install torch>=2.0+cpu
           pip install ".[dev]"
+        
+        # Step 5: Just install pyThermoNDT without dependencies if cache hit
+      - if: steps.cache-pip.outputs.cache-hit == 'true'
+        name: Cache hit
+        run: |
+          echo "Cache hit, just install pyThermoNDT without dependencies"
+          pip install . --no-deps
 
-      # Step 5: Run tests
+      # Step 6: Run tests
       - name: Run Tests
         run: pytest
 
-      # Step 6: Set Output Based on Test Success
+      # Step 7: Set Output Based on Test Success
       - id: set_output
         if: success()
         run: echo "success=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/run_tests.yml` file to optimize the installation of dependencies based on cache hits. The most important changes include conditional installation of dependencies and adjustments to the workflow steps.

Optimizations to dependency installation:

* [`.github/workflows/run_tests.yml`](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L39-R58): Added a conditional step to install dependencies only if there is a cache miss, and to install `pyThermoNDT` without dependencies if there is a cache hit.

Adjustments to workflow steps:

* [`.github/workflows/run_tests.yml`](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L39-R58): Renamed and reordered steps to reflect the new conditional logic for dependency installation and running tests.