### PR TITLE
Move validation for empty and invalid HDF5 BytesIO from the HDF5Parser to deserialization function to catch more errors

### DIFF
--- a/src/pythermondt/data/datacontainer/serialization_ops.py
+++ b/src/pythermondt/data/datacontainer/serialization_ops.py
@@ -79,6 +79,19 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
         Parameters:
             hdf5_bytes (io.BytesIO): The serialized HDF5 data as a BytesIO object.
         """
+        # Check if the BytesIO object is empty
+        if hdf5_bytes.getbuffer().nbytes == 0:
+            raise ValueError("The given BytesIO object is empty.")
+
+        # Check if the BytesIO object is a HDF5 file
+        try:
+            h5py.File(hdf5_bytes)
+        except OSError:
+            raise ValueError("The given BytesIO object does not contain a valid HDF5 file.")
+        
+        # Reset the position of the BytesIO object to the beginning (in case the pointer was moved by the h5py.File function)
+        hdf5_bytes.seek(0)
+
         # Check if a root node exists in the DataContainer ==> if not, add it
         if not self._is_rootnode("/"):
             self.nodes["/"] = RootNode()

--- a/src/pythermondt/readers/parsers/hdf5_parser.py
+++ b/src/pythermondt/readers/parsers/hdf5_parser.py
@@ -19,18 +19,5 @@ class HDF5Parser(BaseParser):
         Raises:
             ValueError: If the given BytesIO object is empty or does not contain a valid HDF5 file.
         """
-        # Check if the BytesIO object is empty
-        if data_bytes.getbuffer().nbytes == 0:
-            raise ValueError("The given BytesIO object is empty.")
-
-        # Check if the BytesIO object is a HDF5 file
-        try:
-            h5py.File(data_bytes)
-        except OSError:
-            raise ValueError("The given BytesIO object does not contain a valid HDF5 file.")
-        
-        # Reset the position of the BytesIO object to the beginning (in case the pointer was moved by the h5py.File function)
-        data_bytes.seek(0)
-
         # Create a new DataContainer from the BytesIO object and return it
         return DataContainer(data_bytes)


### PR DESCRIPTION
This pull request includes changes to improve the handling of `BytesIO` objects in the HDF5 deserialization process by consolidating validation checks into a single method. The most important changes include moving the validation logic from the `parse` function to the `deserialize` method and ensuring that the `BytesIO` object is correctly validated before proceeding.

Consolidation of validation logic:

* [`src/pythermondt/data/datacontainer/serialization_ops.py`](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03R82-R94): Added validation checks to the `deserialize` method to ensure the `BytesIO` object is not empty and contains a valid HDF5 file.
* [`src/pythermondt/readers/parsers/hdf5_parser.py`](diffhunk://#diff-6fb69eed4ead9e6650a02983923dbef8b9c3bdb76718a7328fc8fd123b4f9c77L22-L34): Removed redundant validation checks from the `parse` function, as these checks are now handled in the `deserialize` method.