### PR TITLE
Simplify the input parameters on workflow_call and fix detached head issue when pushing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ quote-style = "double"
 
 # Bump Version
 [tool.bumpversion]
-current_version = "0.1.6dev"
+current_version = "0.1.5dev"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?P<release>dev)?"
 serialize = [
     "{major}.{minor}.{patch}{release}",

--- a/src/pythermondt/__pkginfo__.py
+++ b/src/pythermondt/__pkginfo__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.6dev"
+__version__ = "0.1.5dev"


### PR DESCRIPTION
This pull request simplifies the version bumping workflow by removing unnecessary input parameters and making the checkout steps more specific to the event type. The most important changes include removing the `commit-after-bump` and `push-after-bump` inputs, and adjusting the checkout steps for different GitHub events.

Simplification of version bumping workflow:

* [`.github/workflows/bump_version.yml`](diffhunk://#diff-53150b4763f4a2e08b0d85622cd0640ba3b10eb7a9bca1cfec2b7fb5111b00feL17-L26): Removed the `commit-after-bump` and `push-after-bump` input parameters.
* [`.github/workflows/bump_version.yml`](diffhunk://#diff-53150b4763f4a2e08b0d85622cd0640ba3b10eb7a9bca1cfec2b7fb5111b00feL60-L65): Adjusted the checkout repository steps to handle `workflow_call` and `workflow_dispatch` events separately.
* [`.github/workflows/bump_version.yml`](diffhunk://#diff-53150b4763f4a2e08b0d85622cd0640ba3b10eb7a9bca1cfec2b7fb5111b00feL91-R89): Simplified the `bump` step by always including the `--commit` flag in the `bump-my-version` command.
* [`.github/workflows/post_release.yml`](diffhunk://#diff-7235ed47d43e54136a9c269dc833490c0d3b86f527f83edb114c879fa4ba6f66L15-L16): Removed the `commit-after-bump` and `push-after-bump` input parameters.