### PR TITLE
Fix that transforms are not beeing applied when iterating over a ThermoDataset

### DIFF
--- a/src/pythermondt/data/thermo_dataset.py
+++ b/src/pythermondt/data/thermo_dataset.py
@@ -152,7 +152,7 @@ class ThermoDataset(Dataset):
         return DataContainer()
 
     def __iter__(self) -> Iterator[DataContainer]:
-        return chain.from_iterable(self.__readers)
+        return (self.__transform(data) if self.__transform else data for data in chain.from_iterable(self.__readers))
 
 
 class IndexedThermoDataset(ThermoDataset):


### PR DESCRIPTION
This pull request includes a change to the `__iter__` method in the `ThermoDataset` class to apply a transformation function to the data if it exists.

* [`src/pythermondt/data/thermo_dataset.py`](diffhunk://#diff-490811c591d80b6e4e30d324ab378c9840662e790b797479aca3f6ad75a61148L155-R155): Modified the `__iter__` method to return transformed data if a transformation function (`__transform`) is provided.