### PR TITLE
Fix error handling for the SimulationParser

### DIFF
--- a/src/pythermondt/io/parsers/simulation_parser.py
+++ b/src/pythermondt/io/parsers/simulation_parser.py
@@ -33,7 +33,7 @@ class SimulationParser(BaseParser):
         # Try to load the .mat file using mat73 ==> If it fails the file is not a valid .mat file
         try:
             data = mat73.loadmat(data_bytes, use_attrdict=True)["SimResult"]
-        except OSError as o:
+        except TypeError as o:
             raise ValueError("The given BytesIO object does not contain a valid .mat file.") from o
 
         # Create an empty Thermocontainer ==> predefined structure


### PR DESCRIPTION
This pull request includes a change to the error handling in the `parse` function within the `simulation_parser.py` file. The specific change involves modifying the exception type caught when attempting to load a `.mat` file.

Error handling improvement:

* [`src/pythermondt/io/parsers/simulation_parser.py`](diffhunk://#diff-e4d69aa50023d884e98986a30da1d99a5206f58243cf37905c032417026528d7L36-R36): Changed the exception type from `OSError` to `TypeError` in the `parse` function to correctly handle cases where the input is not a valid `.mat` file.