### PR TITLE
Fix that SimulationParser would load shapes dict as a numpy array instead of an integer

### DIFF
--- a/src/pythermondt/io/parsers/simulation_parser.py
+++ b/src/pythermondt/io/parsers/simulation_parser.py
@@ -89,7 +89,7 @@ class SimulationParser(BaseParser):
                     datacontainer.add_attributes(path="/Data/Tdata", NoiseLevel=data[key])
                 case "Shapes":
                     # Convert the Shapes into a Python dict first:
-                    shapes = {data[key].Names[i]: data[key].Numbers[i] for i in range(len(data[key].Names))}
+                    shapes = {data[key].Names[i]: int(data[key].Numbers[i]) for i in range(len(data[key].Names))}
                     datacontainer.add_attributes(path="/MetaData", Shapes=shapes)
 
         # Return the constructed datapoint


### PR DESCRIPTION
This pull request includes a small but important change to the `parse` function in the `simulation_parser.py` file. The change ensures that the `Shapes` data is correctly converted to integers before being added to the `DataContainer`.

* [`src/pythermondt/io/parsers/simulation_parser.py`](diffhunk://#diff-e4d69aa50023d884e98986a30da1d99a5206f58243cf37905c032417026528d7L92-R92): Modified the `shapes` dictionary comprehension to convert `data[key].Numbers[i]` to an integer.