### PR TITLE
Avoid creating unecessary duplicate temp files in case the file is already cached

### DIFF
--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -306,8 +306,7 @@ class BaseReader(ABC):
         try:
             # If the reader reads from a remote source and files are cached, read the file from the local directory
             if self.remote_source and self.__cache_files and self.__cached_paths is not None:
-                with open(path, "rb") as f:
-                    return self.parser.parse(IOPathWrapper(f.read()))
+                return self.parser.parse(IOPathWrapper(path))
         except FileNotFoundError:
             raise FileNotFoundError("File not found in cached files. Clear the cache and try again.") from None
 


### PR DESCRIPTION
This pull request includes a small change to the `read` method in `src/pythermondt/readers/base_reader.py`. The change simplifies the logic by directly passing the file path to `IOPathWrapper` instead of opening and reading the file manually.