### PR TITLE
Fix ruff warning that version could not be determined

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
         uses: astral-sh/ruff-action@v3.2.2
         with:
           args: "check"
+          version-file: requirements_dev.txt
 
       # Step 3: Set Output Based on Lint Success
       - id: set_output


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/lint.yml` file. The change specifies a `version-file` (`requirements_dev.txt`) for the `ruff-action` to ensure the correct version of dependencies is used.