### PR TITLE
Pass secretes to workflow call

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
         default: ''
+    secrets:
+      WRITE_KEY:
+        description: 'SSH key to push changes'
+        required: true
     outputs:
       bumped:
         description: 'Whether the version was bumped'

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -12,3 +12,5 @@ jobs:
     with:
       bump-type: patch
       ref: main
+    secrets:
+      WRITE_KEY: ${{ secrets.WRITE_KEY }}


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to include a new secret, `WRITE_KEY`, for securely handling SSH keys during automation. The changes ensure that the workflows can push changes to the repository.

### Updates to GitHub Actions workflows:

* [`.github/workflows/bump_version.yml`](diffhunk://#diff-53150b4763f4a2e08b0d85622cd0640ba3b10eb7a9bca1cfec2b7fb5111b00feR17-R20): Added a new `secrets` section with the `WRITE_KEY` secret, which is required and described as an SSH key for pushing changes.
* [`.github/workflows/post_release.yml`](diffhunk://#diff-7235ed47d43e54136a9c269dc833490c0d3b86f527f83edb114c879fa4ba6f66R15-R16): Updated the `jobs` section to pass the `WRITE_KEY` secret from the repository's secrets configuration.