### PR TITLE
Add function to get all dataset paths of a DataContainer object

### DIFF
--- a/src/pythermondt/data/datacontainer/dataset_ops.py
+++ b/src/pythermondt/data/datacontainer/dataset_ops.py
@@ -85,6 +85,14 @@ class DatasetOps(BaseOps):
         """
         return [node.name for node in self.nodes.values() if isinstance(node, DataNode)]
 
+    def get_all_dataset_paths(self) -> list[str]:
+        """Get a list of all dataset paths in the DataContainer.
+
+        Returns:
+            List[str]: A list of paths to all datasets in the DataContainer.
+        """
+        return [path for path, node in self.nodes.items() if isinstance(node, DataNode)]
+
     def remove_dataset(self, path: str):
         """Removes a single dataset from a specified path in the DataContainer.
 


### PR DESCRIPTION
This pull request introduces a new method to the `DataContainer` class in `dataset_ops.py`, enhancing its functionality by allowing retrieval of dataset paths in addition to dataset names.

**Enhancements to `DataContainer` functionality:**

* [`src/pythermondt/data/datacontainer/dataset_ops.py`](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fR88-R95): Added a new method, `get_all_dataset_paths`, which returns a list of paths for all datasets in the `DataContainer`. This complements the existing `get_all_dataset_names` method by providing access to dataset paths.