### PR TITLE
Add a test function for get_all_dataset_paths

### DIFF
--- a/tests/data/datacontainer/test_dataset_ops.py
+++ b/tests/data/datacontainer/test_dataset_ops.py
@@ -340,6 +340,42 @@ def test_get_all_dataset_names(
     assert dataset_names == expected_names
 
 
+# Test getting all dataset paths from the container
+@pytest.mark.parametrize(
+    "datasets",
+    [
+        pytest.param({"dataset0": "sample_tensor", "dataset1": "sample_ndarray", "dataset2": "sample_empty_tensor"}),
+        pytest.param({"dataset0": "sample_empty_ndarray", "dataset1": "sample_empty_tensor", "dataset2": None}),
+        pytest.param({"dataset0": None, "dataset1": "sample_ndarray", "dataset2": "sample_empty_tensor"}),
+        pytest.param({"dataset0": "sample_tensor", "dataset1": None, "dataset2": "sample_empty_ndarray"}),
+    ],
+)
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("/"),  # add directly to root
+        ("/testgroup"),  # add to a group
+        ("/testgroup/nestedgroup"),  # add to a nested group
+    ],
+)
+def test_get_all_dataset_paths(
+    dataset_container: DataContainer, datasets: dict[str, str | None], path: str, request: pytest.FixtureRequest
+):
+    # Request testdata from the fixtures
+    test_data = {key: request.getfixturevalue(value) if value is not None else None for key, value in datasets.items()}
+
+    # Add multiple datasets
+    dataset_container.add_datasets(path, **test_data)
+
+    # Get all dataset paths
+    dataset_paths = dataset_container.get_all_dataset_paths()
+    dataset_paths = set(dataset_paths)  # convert to set for comparison
+
+    # Assertions
+    expected_paths = {validate_path(path, name) for name in datasets.keys()}
+    assert dataset_paths == expected_paths
+
+
 # Test removing a dataset from the container
 @pytest.mark.parametrize(
     "data",


### PR DESCRIPTION
This pull request adds a new test function to validate the functionality of retrieving all dataset paths from a `DataContainer`. The test ensures that datasets added to various paths in the container are correctly reflected when querying for all dataset paths.

### New test addition:

* [`tests/data/datacontainer/test_dataset_ops.py`](diffhunk://#diff-ef4613c5dceef75298b9586dc196dce238e2765d40fb2e74a1fb71350756cc4aR343-R378): Added the `test_get_all_dataset_paths` function, which uses parameterized tests to verify that datasets added to different paths (e.g., root, group, nested group) are correctly retrieved as expected paths. The test uses fixtures to generate test data and validates the output of the `get_all_dataset_paths` method against the expected paths.