### PR TITLE
Fix type error when passing lists of reader subclasses to ThermoDataset

### DIFF
--- a/src/pythermondt/data/thermo_dataset.py
+++ b/src/pythermondt/data/thermo_dataset.py
@@ -17,7 +17,7 @@ class ThermoDataset(Dataset):
     iterate over the data using the __getitem__ method and it is also compatible with PyTorch dataloaders.
     """
 
-    def __init__(self, data_source: BaseReader | list[BaseReader], transform: ThermoTransform | None = None):
+    def __init__(self, data_source: BaseReader | Sequence[BaseReader], transform: ThermoTransform | None = None):
         """Initialize a custom PyTorch dataset from a list of readers.
 
         The sources are used to read the data and create the dataset. First the readers are grouped by type.
@@ -42,7 +42,7 @@ class ThermoDataset(Dataset):
             ValueError: If any of the readers of the same type do not find any files
         """
         # Convert single reader to list
-        data_source = data_source if isinstance(data_source, list) else [data_source]
+        data_source = [data_source] if isinstance(data_source, BaseReader) else list(data_source)
 
         # Validate the readers
         self._validate_readers(data_source)


### PR DESCRIPTION
This pull request updates the `ThermoDataset` class in `src/pythermondt/data/thermo_dataset.py` to improve type flexibility and handling of the `data_source` parameter. Key changes include replacing `list` with `Sequence` for type annotations and modifying how single readers are converted into lists.

Enhancements to type flexibility and input handling:

* Modified the `data_source` parameter type in the `__init__` method from `BaseReader | list[BaseReader]` to `BaseReader | Sequence[BaseReader]` to allow for more flexible input types. (`src/pythermondt/data/thermo_dataset.py`, [src/pythermondt/data/thermo_dataset.pyL20-R20](diffhunk://#diff-490811c591d80b6e4e30d324ab378c9840662e790b797479aca3f6ad75a61148L20-R20))
* Updated the logic for converting a single `BaseReader` instance into a list to ensure compatibility with `Sequence` inputs, using `list(data_source)` for non-`BaseReader` sequences. (`src/pythermondt/data/thermo_dataset.py`, [src/pythermondt/data/thermo_dataset.pyL45-R45](diffhunk://#diff-490811c591d80b6e4e30d324ab378c9840662e790b797479aca3f6ad75a61148L45-R45))