### PR TITLE
Rename the release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,4 +1,4 @@
-name: Build and Release Python Package
+name: Prepare Release
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/prepare_release.yml` file. The workflow name has been changed from "Build and Release Python Package" to "Prepare Release" for better clarity.