### PR TITLE
Add a new flash detection method using mean temperature drop to RemoveFlash transform

### DIFF
--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -111,7 +111,8 @@ class RemoveFlash(ThermoTransform):
         - "excitation_signal": Detect the flash by finding the frame where the excitation signal goes from 1 back to 0.
         - "max_temp": Detect the flash by finding the frame with the maximum temperature value in it.
             May not work if the flash is not the hottest frame.
-        - "mean_temp_drop": Detect the flash by finding the largest temperature drop in the mean temperature.
+        - "mean_temp_drop": Detect the flash by finding the largest temperature drop in the mean temperature over all
+            frames. This is the most reliable method if excitation signal is not available.
 
         Parameters:
             method (Literal["excitation_signal", "max_temp"]): Method to detect the flash.


### PR DESCRIPTION
This pull request introduces a new method for detecting the flash in the `RemoveFlash` class, enhancing its flexibility and reliability. The most important changes include adding the "mean_temp_drop" method as an option for flash detection and implementing its logic in the `forward` method.

### Enhancements to flash detection:

* [`src/pythermondt/transforms/preprocessing.py`](diffhunk://#diff-826240ce6178741d180dbe0504ff6244e08582bed76375daf52f841b0bcd4d4bL105-R115): Added the "mean_temp_drop" method to the `RemoveFlash` class. This method detects the flash by identifying the largest temperature drop in the mean temperature across all frames, providing a more reliable option when the excitation signal is unavailable.
* [`src/pythermondt/transforms/preprocessing.py`](diffhunk://#diff-826240ce6178741d180dbe0504ff6244e08582bed76375daf52f841b0bcd4d4bR149-R154): Implemented the logic for the "mean_temp_drop" method in the `forward` method, calculating the largest temperature drop using `torch.diff` and determining the corresponding frame index.