### PR TITLE
Refactor split_transforms_for_caching to support Compose input and return the output as composed transforms

### DIFF
--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -33,7 +33,7 @@ def split_transforms_for_caching(
 ) -> tuple[Compose, Compose]:
     """Split any composed transforms into deterministic and random transforms.
 
-    This function takes a sequence of transforms and splits them into two lists:
+    This function takes a sequence of transforms or a Compose object and splits them into two Compose objects:
     - Deterministic transforms
     - Random transforms and any transforms that follow them
 
@@ -41,13 +41,13 @@ def split_transforms_for_caching(
     split is applied to the individual transforms rather than the Compose container itself.
 
     Parameters:
-        transforms (Sequence[_BaseTransform]): A sequence of transforms to split.
+        transforms (Sequence[_BaseTransform] | Compose): A sequence of transforms or Compose object to split.
 
     Returns:
-        tuple[Sequence[_BaseTransform], Sequence[_BaseTransform]]:
-            A tuple containing two lists:
-            - The first list contains deterministic transforms.
-            - The second list contains random transforms and any transforms that follow them.
+        tuple[Compose, Compose]:
+            A tuple containing two Compose objects:
+            - The first contains deterministic transforms.
+            - The second contains random transforms and any transforms that follow them.
     """
     # Flatten nested Compose transforms first
     flat_transforms = _flatten_transforms(transforms.transforms if isinstance(transforms, Compose) else transforms)


### PR DESCRIPTION
This pull request updates the `split_transforms_for_caching` function in `src/pythermondt/transforms/utils.py` to enhance its functionality and improve its usability. The most significant changes include modifying the function to handle `Compose` objects, updating the return type to `Compose`, and adjusting the implementation accordingly.

### Enhancements to `split_transforms_for_caching`:

* Updated the `transforms` parameter to accept either a sequence of `_BaseTransform` or a `Compose` object, broadening the function's applicability.
* Changed the return type from a tuple of sequences to a tuple of `Compose` objects, ensuring consistency with the input type and simplifying downstream usage.
* Adjusted the implementation to flatten transforms based on whether the input is a `Compose` object, improving handling of nested `Compose` structures.
* Modified the return statement to wrap the deterministic and random transforms in `Compose` objects, aligning with the updated return type.