### PR TITLE
Pin dev dependencies to have consistent environments

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
-pytest~=8.4
-pytest-cov~=6.2
-ruff~=0.12
-pre-commit~=4.2
-bump-my-version~=1.2
-deepdiff~=8.5
-licensecheck~=2025.1
-mypy~=1.16
+pytest==8.4.1
+pytest-cov==6.2.1
+ruff==0.12.0
+pre-commit==4.2.0
+bump-my-version==1.2.0
+deepdiff==8.5.0
+licensecheck==2025.1.0
+mypy==1.16.1


### PR DESCRIPTION
This pull request updates the development dependencies in `requirements_dev.txt` to pin them to specific patch versions for improved stability and reproducibility.

Dependency updates:

* Updated `pytest` to version `8.4.1`.
* Updated `pytest-cov` to version `6.2.1`.
* Updated `ruff` to version `0.12.0`.
* Updated `pre-commit` to version `4.2.0`.
* Updated `bump-my-version` to version `1.2.0`.
* Updated `deepdiff` to version `8.5.0`.
* Updated `licensecheck` to version `2025.1.0`.
* Updated `mypy` to version `1.16.1`.