### PR TITLE
Make download() independent of download_files flag to have more consistent behaviour

### DIFF
--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -26,8 +26,8 @@ class BaseReader(ABC):
         Parameters:
             num_files (int, optional): The number of files to read. If not specified, all files will be read.
                 Default is None.
-            download_files (bool, optional): Whether to download remote files to local storage. Set this
-                to True if frequent access to the same files is needed. Default is False to avoid unnecessary downloads.
+            download_files (bool, optional): Whether to automatically cache remote files locally during operations.
+                When False, files are downloaded on-demand but not saved locally. Default is False.
             cache_files (bool, optional): Whether to cache the files list in memory. If set to False, changes to the
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
@@ -236,11 +236,13 @@ class BaseReader(ABC):
         return local_path
 
     def download(self, file_paths: list[str] | None = None) -> None:
-        """Trigger the download of files from the remotes source.
+        """Trigger the download of files from the remote source.
 
         This method will download the specified files from the remote source and cache them locally in the reader's
-        cache directory. The download will will only happen if the reader has a remote source and only files that are
+        cache directory. The download will only happen if the reader has a remote source and only files that are
         not already cached locally will be downloaded.
+
+        **Note:** This works regardless of the `download_files` flag, set during reader initialization.
 
         Parameters:
             file_paths (list[str], optional): List of file paths to download. If None, all files that the reader is

--- a/src/pythermondt/readers/s3_reader.py
+++ b/src/pythermondt/readers/s3_reader.py
@@ -31,8 +31,8 @@ class S3Reader(BaseReader):
                 the default profile from the AWS configuration.
             num_files (int, optional): The number of files to read. If not specified, all files will be read.
                 Default is None.
-            download_files (bool, optional): Whether to download remote files to local storage. Set this
-                to True if frequent access to the same files is needed. Default is False to avoid unnecessary downloads.
+            download_files (bool, optional): Whether to automatically cache remote files locally during operations.
+                When False, files are downloaded on-demand but not saved locally. Default is False.
             cache_files (bool, optional): Whether to cache the files list in memory. If set to False, changes to the
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,


### PR DESCRIPTION
This pull request refines the behavior and documentation of file caching and downloading in the `BaseReader` and `S3Reader` classes. The most important changes include clarifying the `download_files` parameter, modifying the `download` method to ensure caching irrespective of the `download_files` flag, and improving the method documentation.

### Updates to file caching and downloading behavior:

* [`src/pythermondt/readers/base_reader.py`](diffhunk://#diff-a66c06248fb1a8e718053a19c795ff8ecc71222c1f5e8cc34c5f4b318c6c91dfL29-R30): Updated the `download_files` parameter description in the `__init__` method to clarify its behavior, specifying that files are downloaded on-demand but not cached locally when set to `False`.
* [`src/pythermondt/readers/s3_reader.py`](diffhunk://#diff-2d4708ea95406730479045f24a7db5c24792d34072eca18d0be5cdf1a8189c35L34-R35): Applied the same clarification to the `download_files` parameter description in the `S3Reader` class's `__init__` method.

### Improvements to the `download` method:

* [`src/pythermondt/readers/base_reader.py`](diffhunk://#diff-a66c06248fb1a8e718053a19c795ff8ecc71222c1f5e8cc34c5f4b318c6c91dfL239-R252): Modified the `download` method to ensure files are cached locally in the reader's cache directory, regardless of the `download_files` flag set during initialization. Updated the method documentation to reflect this behavior.