### PR TITLE
Introduce a basic plugin system to dynamically load custom parsers. Can be extended in the future for further usecases.

### DIFF
--- a/src/pythermondt/io/parsers/__init__.py
+++ b/src/pythermondt/io/parsers/__init__.py
@@ -56,7 +56,7 @@ def get_all_parsers() -> list[type[BaseParser]]:
     Returns:
         List of all parser classes
     """
-    return PARSER_REGISTRY
+    return PARSER_REGISTRY.copy()
 
 
 __all__ = [


### PR DESCRIPTION
- Added support for loading custom parsers via Python entry points under the `pythermondt.parsers` group
- Extended the parser registry to include both built-in and plugin-defined parsers
- Introduced `get_all_parsers` to expose the full list of registered parser classes

This initial plugin system enables dynamic integration of external parsers and sets the foundation for supporting additional plugin-based features in the future.