### PR TITLE
Remove local-dev entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# Ignore local dev files
-*/local_dev/*
-local_dev/*
-*/local-dev/*
-local-dev/*
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
- Remove all local-dev patterns from `.gitignore`

These entries should be handled by each developer's global Git configuration rather than the project-level `.gitignore` to avoid committing personal development paths.
