### PR TITLE
Fix potential off-by-one bug in RemoveFlash by avoiding excitation_signal[-1] access

### DIFF
--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -134,7 +134,7 @@ class RemoveFlash(ThermoTransform):
             case "excitation_signal":
                 # Find frame where excitation signal goes from 1 back to 0 (flash end)
                 flash_end_idx = None
-                for i in range(len(excitation_signal)):
+                for i in range(1, len(excitation_signal)):  # Start at 1
                     if excitation_signal[i - 1] == 1 and excitation_signal[i] == 0:
                         flash_end_idx = i + self.offset
                         break


### PR DESCRIPTION
- Change iteration start index from 0 to 1 in the flash detection algorithm for the excitation signal in the `RemoveFlash` transform
- Prevent unintended access to `excitation_signal[-1]`, which wraps to the last element in Python

Previously, the loop started at index 0, which caused the first check to access `excitation_signal[-1]` and `excitation_signal[0]`. While syntactically valid in Python, this could lead to incorrect behavior or false detection of the flash end when the last and first signal elements meet the condition.
