### PR TITLE
Rename Parameters to Args so that ruff correctly detects the docstring type

### DIFF
--- a/src/pythermondt/data/datacontainer/attribute_ops.py
+++ b/src/pythermondt/data/datacontainer/attribute_ops.py
@@ -7,7 +7,7 @@ class AttributeOps(BaseOps):
     def add_attribute(self, path: str, key: str, value: str | int | float | list | tuple | dict | Unit):
         """Adds an attribute to the specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             key (str): The key of the attribute.
             value (str | int | float | list | tuple | dict | UnitInfo): The value of the attribute.
@@ -21,7 +21,7 @@ class AttributeOps(BaseOps):
     def add_attributes(self, path: str, **attributes: str | int | float | list | tuple | dict | Unit):
         """Adds multiple attributes to the specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             **attributes (Dict[str, str | int | float | list | tuple | dict | UnitInfo]): The attributes to add.
 
@@ -34,7 +34,7 @@ class AttributeOps(BaseOps):
     def add_unit(self, path: str, unit: Unit):
         """Adds the unit information to the specified dataset.
 
-        Parameters:
+        Args:
             path (str): The path to the dataset.
             unit (UnitInfo): The unit to add.
 
@@ -47,7 +47,7 @@ class AttributeOps(BaseOps):
     def get_attribute(self, path: str, key: str) -> str | int | float | list | tuple | dict | Unit:
         """Get a single attribute from a specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             key (str): The key of the attribute.
 
@@ -63,7 +63,7 @@ class AttributeOps(BaseOps):
     def get_attributes(self, path: str, *keys: str) -> tuple[str | int | float | list | tuple | dict | Unit, ...]:
         """Get multiple attributes from a specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             *keys (str): Variable number of attribute keys.
                 Can be provided as separate arguments or unpacked from a list.
@@ -80,7 +80,7 @@ class AttributeOps(BaseOps):
     def get_all_attributes(self, path: str) -> dict[str, str | int | float | list | tuple | dict | Unit]:
         """Get all attributes from a specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
 
         Returns:
@@ -94,7 +94,7 @@ class AttributeOps(BaseOps):
     def get_unit(self, path: str) -> Unit:
         """Get the unit information from the specified dataset.
 
-        Parameters:
+        Args:
             path (str): The path to the dataset.
 
         Returns:
@@ -115,7 +115,7 @@ class AttributeOps(BaseOps):
     def remove_attribute(self, path: str, key: str):
         """Remove an attribute from a specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             key (str): The key of the attribute.
 
@@ -128,7 +128,7 @@ class AttributeOps(BaseOps):
     def update_attribute(self, path: str, key: str, value: str | int | float | list | tuple | dict | Unit):
         """Update an attribute in a specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             key (str): The key of the attribute.
             value (str | int | float | list | tuple | dict | UnitInfo): The new value of the attribute.
@@ -142,7 +142,7 @@ class AttributeOps(BaseOps):
     def update_attributes(self, path: str, **attributes: str | int | float | list | tuple | dict | Unit):
         """Update multiple attributes in a specified group or dataset in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the group or dataset.
             **attributes (Dict[str, str | int | float | list | tuple | dict | UnitInfo]): The new attributes.
 
@@ -155,7 +155,7 @@ class AttributeOps(BaseOps):
     def update_unit(self, path: str, unit: Unit):
         """Update the unit information of the specified dataset.
 
-        Parameters:
+        Args:
             path (str): The path to the dataset.
             unit (UnitInfo): The new unit information.
 

--- a/src/pythermondt/data/datacontainer/base.py
+++ b/src/pythermondt/data/datacontainer/base.py
@@ -164,7 +164,7 @@ class BaseOps(DataContainerBase):
     def _path_exists(self, key: str) -> bool:
         """Check if a path exists in the DataContainer.
 
-        Parameters:
+        Args:
             key (str): The path to check.
 
         Returns:
@@ -179,7 +179,7 @@ class BaseOps(DataContainerBase):
     def _is_datanode(self, key: str) -> bool:
         """Check if a DataNode exists at the given path.
 
-        Parameters:
+        Args:
             key (str): The path to check.
 
         Returns:
@@ -194,7 +194,7 @@ class BaseOps(DataContainerBase):
     def _is_groupnode(self, key: str) -> bool:
         """Check if a GroupNode exists at the given path.
 
-        Parameters:
+        Args:
             key (str): The path to check.
 
         Returns:
@@ -209,7 +209,7 @@ class BaseOps(DataContainerBase):
     def _is_rootnode(self, key: str) -> bool:
         """Check if a RootNode exists at the given path.
 
-        Parameters:
+        Args:
             key (str): The path to check.
 
         Returns:
@@ -226,7 +226,7 @@ class BaseOps(DataContainerBase):
 
         If the path itself is the root path, it returns False.
 
-        Parameters:
+        Args:
             key (str): The path to check.
 
         Returns:

--- a/src/pythermondt/data/datacontainer/core.py
+++ b/src/pythermondt/data/datacontainer/core.py
@@ -26,7 +26,7 @@ class DataContainer(SerializationOps, DeserializationOps, VisualizationOps, Grou
         By default, initializes an empty DataContainer.
         If a serialized HDF5 file is provided, the DataContainer is initialized with the data from the BytesIO object.
 
-        Parameters:
+        Args:
             hdf5_data (BytesIO | None): The HDF5 file to deserialize. Defaults to None.
         """
         super().__init__()
@@ -59,7 +59,7 @@ class DataContainer(SerializationOps, DeserializationOps, VisualizationOps, Grou
         that have undergone stochastic transforms (e.g. GaussianNoise) will not be equal
         since their data differs.
 
-        Parameters:
+        Args:
             other (object): The other object to compare with.
 
         Returns:

--- a/src/pythermondt/data/datacontainer/dataset_ops.py
+++ b/src/pythermondt/data/datacontainer/dataset_ops.py
@@ -11,7 +11,7 @@ class DatasetOps(BaseOps):
     def add_dataset(self, path: str, name: str, data: Tensor | ndarray | None = None):
         """Adds a single dataset to a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the parent group.
             name (str): The name of the dataset to add.
             data (Tensor, optional): The data to store in the dataset. If None, an empty dataset is created.
@@ -34,7 +34,7 @@ class DatasetOps(BaseOps):
     def add_datasets(self, path: str, **datasets: Tensor | ndarray | None):
         """Adds multiple datasets to a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the parent group.
             **datasets (Dict[str, Optional[Tensor | ndarray]]): The datasets to add, provided as a dictionary.
                 The specified key will become the name of the dataset.
@@ -49,7 +49,7 @@ class DatasetOps(BaseOps):
     def get_dataset(self, path: str) -> Tensor:
         """Get a single dataset from a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the dataset
 
         Returns:
@@ -64,7 +64,7 @@ class DatasetOps(BaseOps):
     def get_datasets(self, *paths: str) -> tuple[Tensor, ...]:
         """Get multiple datasets from specified paths in the DataContainer.
 
-        Parameters:
+        Args:
             *paths (str): Variable number of paths to the datasets.
                 Can be provided as separate arguments or unpacked from a list.
 
@@ -96,7 +96,7 @@ class DatasetOps(BaseOps):
     def remove_dataset(self, path: str):
         """Removes a single dataset from a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the dataset
 
         Raises:
@@ -110,7 +110,7 @@ class DatasetOps(BaseOps):
     def update_dataset(self, path: str, data: Tensor | ndarray):
         """Updates a single dataset at a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the dataset.
             data (Tensor): The new data to store in the dataset.
 
@@ -126,7 +126,7 @@ class DatasetOps(BaseOps):
     def update_datasets(self, *updates: tuple[str, Tensor | ndarray]):
         """Update multiple datasets in the DataContainer.
 
-        Parameters:
+        Args:
             *updates (Tuple[str, Tensor | ndarray]): Variable number of (path, data) tuples.
                 Can be provided as separate tuples or unpacked from a list.
 

--- a/src/pythermondt/data/datacontainer/group_ops.py
+++ b/src/pythermondt/data/datacontainer/group_ops.py
@@ -7,7 +7,7 @@ class GroupOps(BaseOps):
     def add_group(self, path: str, name: str):
         """Adds a single group to a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the parent group.
             name (str): The name of the group to add.
 
@@ -29,7 +29,7 @@ class GroupOps(BaseOps):
     def remove_group(self, path: str):
         """Removes a single group from a specified path in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the parent group.
 
         Raises:

--- a/src/pythermondt/data/datacontainer/serialization_ops.py
+++ b/src/pythermondt/data/datacontainer/serialization_ops.py
@@ -18,7 +18,7 @@ class SerializationOps(BaseOps):
     def serialize_to_hdf5(self, compression: Literal["lzf", "gzip"] = "lzf", compression_opts: int = 4) -> BytesIO:
         """Serializes the DataContainer instance to an HDF5 file.
 
-        Parameters:
+        Args:
             compression (Literal["lzf", "gzip"]): The compression method to use for the HDF5 file.
                 Default is "lzf" which is a fast compression method. If you want smaller files,
                 use "gzip" instead, but it is slower.
@@ -68,7 +68,7 @@ class SerializationOps(BaseOps):
     def _add_attributes(self, h5obj: h5py.Dataset | h5py.Group, attributes: ItemsView[str, AttributeTypes]):
         """Adds attributes to an HDF5 object (group or dataset).
 
-        Parameters:
+        Args:
             h5obj (h5py.Group or h5py.Dataset): The HDF5 object to add attributes to.
             attributes (Dict[str, str | int | float | list | tuple | dict]): The attributes to add.
         """
@@ -83,7 +83,7 @@ class SerializationOps(BaseOps):
     def save_to_hdf5(self, path: str, compression: Literal["lzf", "gzip"] = "lzf", compression_opts: int = 4):
         """Saves the serialized DataContainer to an HDF5 file at the specified path.
 
-        Parameters:
+        Args:
             path (str): The path where the HDF5 file should be saved.
             compression (Literal["lzf", "gzip"]): The compression method to use for the HDF5 file.
                 Default is "lzf" which is a fast compression method. If you want smaller files,
@@ -99,7 +99,7 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
     def deserialize(self, hdf5_data: BytesIO):
         """Deserializes an HDF5 file into the DataContainer instance.
 
-        Parameters:
+        Args:
             hdf5_data (BytesIO): The HDF5 file to deserialize.
         """
         # Check if the IOPathWrapper object is empty
@@ -132,7 +132,7 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
     def _process_group(self, path: str, name: str, group: h5py.Group):
         """Processes and adds one group and its subgroups and datasets to the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the parent where the group should be added.
             name (str): The name of the group.
             group (h5py.Group): The group to process.
@@ -158,7 +158,7 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
     def _process_dataset(self, path: str, name: str, dataset: h5py.Dataset):
         """Processes and adds a dataset to the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the parent group where the dataset should be added.
             name (str): The name of the dataset.
             dataset (h5py.Dataset): The dataset to process.
@@ -173,7 +173,7 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
     def _process_attributes(self, path: str, attributes: dict[str, Any]):
         """Processes and adds attributes to a node in the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path to the node.
             attributes (Dict[str, Any]): The attributes to add to the node.
         """
@@ -207,7 +207,7 @@ class DeserializationOps(GroupOps, DatasetOps, AttributeOps):
     def load_from_hdf5(self, path: str):
         """Loads an HDF5 file from the specified path and deserializes it into the DataContainer.
 
-        Parameters:
+        Args:
             path (str): The path of the HDF5 file to load.
         """
         with open(path, "rb") as file:

--- a/src/pythermondt/data/datacontainer/utils.py
+++ b/src/pythermondt/data/datacontainer/utils.py
@@ -7,7 +7,7 @@ from .node import BaseNode, DataNode, GroupNode, NodeType, RootNode
 def is_rootnode(node: BaseNode) -> "TypeGuard[RootNode]":
     """Checks if the given node is a RootNode.
 
-    Parameters:
+    Args:
         node (BaseNode): The node to check.
 
     Returns:
@@ -19,7 +19,7 @@ def is_rootnode(node: BaseNode) -> "TypeGuard[RootNode]":
 def is_groupnode(node: BaseNode) -> "TypeGuard[GroupNode]":
     """Checks if the given node is a GroupNode.
 
-    Parameters:
+    Args:
         node (BaseNode): The node to check.
 
     Returns:
@@ -31,7 +31,7 @@ def is_groupnode(node: BaseNode) -> "TypeGuard[GroupNode]":
 def is_datanode(node: BaseNode) -> "TypeGuard[DataNode]":
     """Checks if the given node is a DataNode.
 
-    Parameters:
+    Args:
         node (BaseNode): The node to check.
 
     Returns:
@@ -43,7 +43,7 @@ def is_datanode(node: BaseNode) -> "TypeGuard[DataNode]":
 def validate_path(path: str, name: str = "") -> str:
     """Validates and normalizes the given HDF5 path.
 
-    Parameters:
+    Args:
         path (str): The path to validate and normalize.
         name (str, optional): The name of the group or dataset to add to the path. Defaults to "".
 
@@ -82,7 +82,7 @@ def validate_path(path: str, name: str = "") -> str:
 def validate_paths(paths: list[str]) -> tuple[str, ...]:
     """Validates and normalizes the given list of HDF5 paths.
 
-    Parameters:
+    Args:
         paths (List[str]): The list of paths to validate and normalize.
 
     Returns:
@@ -97,7 +97,7 @@ def validate_paths(paths: list[str]) -> tuple[str, ...]:
 def split_path(path: str) -> tuple[str, str]:
     """Splits the given HDF5 path into the parent path and the name of the group or dataset.
 
-    Parameters:
+    Args:
         path (str): The path to split.
 
     Returns:
@@ -116,7 +116,7 @@ def generate_key(path: str, name: str) -> tuple[str, str, str]:
     First the path is validated and normalized, then it is split into the parent path and the name of the
     group or dataset.
 
-    Parameters:
+    Args:
         path (str): The path to generate the key for.
         name (str): The name of the group or dataset.
 

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -17,7 +17,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         def __init__(self, parent: "VisualizationOps"):
             """Initialize the interactive analyzer for thermographic data visualization.
 
-            Parameters:
+            Args:
                 parent (VisualizationOps): The parent container for the interactive analysis.
             """
             # 1.) Retrieve data from the container
@@ -204,7 +204,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
     def show_frame(self, frame_number: int, option: str = "", cmap: str = "plasma"):
         """Visualize a specific frame from the dataset with optional ground truth visualization and color mapping.
 
-        Parameters:
+        Args:
             frame_number (int): The frame number to visualize.
             option (str): The visualization option to apply.
                 Options are "ShowGroundTruth", "OverlayGroundTruth", or an empty string.
@@ -262,7 +262,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         The X-axis of the plot is labeled according to the domaintype attribute, reflecting the dataset's domain
         (e.g., time, frequency). The Y-axis is generically labeled as 'Temperature in K'.
 
-        Parameters:
+        Args:
             pixel_pos_x (int): The X-coordinate (column index) of the pixel.
                 Must be within the dataset's second dimension range.
             pixel_pos_y (int): The Y-coordinate (row index) of the pixel.

--- a/src/pythermondt/data/units/_unit.py
+++ b/src/pythermondt/data/units/_unit.py
@@ -12,7 +12,7 @@ class Unit(TypedDict):
 def is_unit_info(obj: Any) -> TypeGuard[Unit]:
     """TypeGuard to check if an object is a valid UnitInfo.
 
-    Parameters:
+    Args:
         obj (Any): The object to check.
 
     Returns:

--- a/src/pythermondt/data/units/utils.py
+++ b/src/pythermondt/data/units/utils.py
@@ -5,7 +5,7 @@ from .units import Units
 def generate_label(unit: Unit) -> str:
     """Generates a label from a UnitInfo object.
 
-    Parameters:
+    Args:
         unit (UnitInfo): The UnitInfo object to generate the label from.
 
     Returns:

--- a/src/pythermondt/dataset/base.py
+++ b/src/pythermondt/dataset/base.py
@@ -143,7 +143,7 @@ class BaseDataset(Dataset, ABC):
             **Windows**: Use lazy mode to avoid memory issues due to cache duplication in forked processes
             **Linux**: Both modes work efficiently - choose based on workflow preference
 
-        Parameters:
+        Args:
             mode (CacheMode): Cache building strategy
                 - "lazy": Create shared cache, workers fill on-demand for faster startup (default)
                 - "immediate": Build all items upfront using a ThreadPool

--- a/src/pythermondt/dataset/indexed_thermo_dataset.py
+++ b/src/pythermondt/dataset/indexed_thermo_dataset.py
@@ -17,7 +17,7 @@ class IndexedThermoDataset(BaseDataset):
     def __init__(self, dataset: BaseDataset, indices: Sequence[int], transform: ThermoTransform | None = None):
         """Initialize an indexed dataset with optional additional transform.
 
-        Parameters:
+        Args:
             dataset (ThermoDataset): Parent dataset to index into
             indices (Sequence[int]): Sequence of indices to select from parent
             transform (ThermoTransform, optional): Optional transform to apply after parent's transform

--- a/src/pythermondt/dataset/thermo_dataset.py
+++ b/src/pythermondt/dataset/thermo_dataset.py
@@ -21,7 +21,7 @@ class ThermoDataset(BaseDataset):
         Files are discovered and downloaded (if remote) during initialization for
         predictable performance during training.
 
-        Parameters:
+        Args:
             data_source: Single reader or list of readers to combine
             transform: Optional transform applied to each container when loaded
 

--- a/src/pythermondt/dataset/utils.py
+++ b/src/pythermondt/dataset/utils.py
@@ -25,7 +25,7 @@ def random_split(
     After computing the lengths, if there are any remainders, 1 count will be distributed in round-robin fashion to the
     lengths until there are no remainders left.
 
-    Parameters:
+    Args:
         dataset (Dataset): Dataset to be split
         lengths (Sequence[float]): Fractions for each split that sum up to 1.0.
         transforms (Sequence[ThermoTransform | None], optional): Optional sequence of transforms for each split.
@@ -101,7 +101,7 @@ def container_collate(*paths: str) -> Callable[[Sequence[DataContainer]], tuple[
 
     Returns a function that extracts specified dataset paths and stacks them along batch dimension.
 
-    Parameters:
+    Args:
         *paths (str): Variable number of dataset paths to extract (e.g. '/Data/Tdata', '/GroundTruth/DefectMask')
 
     Returns:

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -13,7 +13,7 @@ class LocalBackend(BaseBackend):
 
         This class is used to read data from local files, or directories, using the standard Python file I/O operations.
 
-        Parameters:
+        Args:
             pattern (Pattern | str): The source of the data. This must be a valid file path, directory path, or a regex
                 pattern. If a regex pattern is provided, it will be used to determine the files using glob.
         """

--- a/src/pythermondt/io/backends/s3_backend.py
+++ b/src/pythermondt/io/backends/s3_backend.py
@@ -36,7 +36,7 @@ class S3Backend(BaseBackend):
     def read_file(self, file_path: str) -> IOPathWrapper:
         """Read a file from S3.
 
-        Parameters:
+        Args:
             file_path (str): Path to file, either full S3 URI or key within bucket
 
         Returns:
@@ -58,7 +58,7 @@ class S3Backend(BaseBackend):
     def write_file(self, data: IOPathWrapper, file_path: str) -> None:
         """Write file to S3.
 
-        Parameters:
+        Args:
             data (IOPathWrapper): File data to write
             file_path (str): Destination path
         """
@@ -73,7 +73,7 @@ class S3Backend(BaseBackend):
     def exists(self, file_path: str) -> bool:
         """Check if a file exists in S3.
 
-        Parameters:
+        Args:
             file_path (str): Path to check
 
         Returns:
@@ -99,7 +99,7 @@ class S3Backend(BaseBackend):
     def get_file_list(self, extensions: tuple[str, ...] | None = None, num_files: int | None = None) -> list[str]:
         """Get list of files from S3 with optional filtering.
 
-        Parameters:
+        Args:
             extensions (tuple[str, ...], optional): Filter by file extensions
             num_files (int, optional): Limit number of files returned
 
@@ -137,7 +137,7 @@ class S3Backend(BaseBackend):
     def download_file(self, source_path: str, destination_path: str) -> None:
         """Download a file from S3 to local filesystem.
 
-        Parameters:
+        Args:
             source_path (str): Source S3 path
             destination_path (str): Destination local path
         """
@@ -151,7 +151,7 @@ class S3Backend(BaseBackend):
 
         Handles both s3://bucket/key format and relative paths.
 
-        Parameters:
+        Args:
             path (str): Path to parse
 
         Returns:

--- a/src/pythermondt/io/parsers/__init__.py
+++ b/src/pythermondt/io/parsers/__init__.py
@@ -24,7 +24,7 @@ PARSER_REGISTRY: list[type[BaseParser]] = [HDF5Parser, SimulationParser] + _load
 def find_parser_for_extension(extension: str) -> type[BaseParser] | None:
     """Find a parser that supports the given file extension.
 
-    Parameters:
+    Args:
         extension: File extension (with or without leading dot)
 
     Returns:

--- a/src/pythermondt/io/parsers/base_parser.py
+++ b/src/pythermondt/io/parsers/base_parser.py
@@ -41,7 +41,7 @@ class BaseParser(Protocol):
 
         Subclasses must implement this method.
 
-        Parameters:
+        Args:
             data (IOPathWrapper): IOPathWrapper object containing the data to be parsed.
 
         Returns:

--- a/src/pythermondt/io/parsers/hdf5_parser.py
+++ b/src/pythermondt/io/parsers/hdf5_parser.py
@@ -12,7 +12,7 @@ class HDF5Parser(BaseParser):
 
         The IOPathWrapper object must contain a serialized DataContainer object in HDF5 format.
 
-        Parameters:
+        Args:
             data (IOPathWrapper): IOPathWrapper object containing the data to be parsed.
 
         Returns:

--- a/src/pythermondt/io/parsers/simulation_parser.py
+++ b/src/pythermondt/io/parsers/simulation_parser.py
@@ -19,7 +19,7 @@ class SimulationParser(BaseParser):
 
         The IOPathWrapper object must contain a .mat file with simulattion data from COMSOL.
 
-        Parameters:
+        Args:
             data (IOPathWrapper): IOPathWrapper object containing the data to be parsed.
 
         Returns:

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -26,7 +26,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     ):
         """Initialize an instance of the BaseReader class.
 
-        Parameters:
+        Args:
             num_files (int, optional): The number of files to read. If not specified, all files will be read.
                 Default is None.
             download_files (bool, optional): Whether to automatically cache remote files locally during operations.
@@ -228,7 +228,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     def _download_single_file(self, remote_path: str, manifest: dict[str, str]) -> tuple[str, str]:
         """Download a single file from the remote source and return its local path.
 
-        Parameters:
+        Args:
             remote_path (str): The path to the file on the remote source.
             manifest (dict[str, str]): The manifest dictionary containing the current state of downloaded files.
 
@@ -252,7 +252,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     def _ensure_file_cached(self, remote_path: str) -> str:
         """Ensure a file is cached locally, return local path.
 
-        Parameters:
+        Args:
             remote_path (str): The path to the file on the remote source.
 
         Returns:
@@ -281,7 +281,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
         **Note:** This works regardless of the `download_files` flag, set during reader initialization.
 
-        Parameters:
+        Args:
             file_paths (list[str], optional): List of file paths to download. If None, all files that the reader is
                 able to read will be downloaded. Default is None.
             num_workers (int, optional): Number of workers to use for downloading files. If None, the global

--- a/src/pythermondt/readers/local_reader.py
+++ b/src/pythermondt/readers/local_reader.py
@@ -16,7 +16,7 @@ class LocalReader(BaseReader):
 
         Uses the LocalBackend to read files from the local file system.
 
-        Parameters:
+        Args:
             pattern (Pattern | str): The pattern to match files. Can be a string or a compiled regex pattern.
             num_files (int, optional): The number of files to read. If not specified, all files will be read.
                 Default is None.

--- a/src/pythermondt/readers/s3_reader.py
+++ b/src/pythermondt/readers/s3_reader.py
@@ -22,7 +22,7 @@ class S3Reader(BaseReader):
         authentication method for AWS, according to the documentation:
         https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html#configuration
 
-        Parameters:
+        Args:
             bucket (str): The name of the S3 bucket.
             prefix (str): The prefix (path) within the S3 bucket.
             region_name (str, optional): The AWS region name, e.g. eu-central-1 used when creating new connections.

--- a/src/pythermondt/transforms/augmentation.py
+++ b/src/pythermondt/transforms/augmentation.py
@@ -17,7 +17,7 @@ class RandomFlip(RandomThermoTransform):
         The flipping occurs along the height (vertical flip) and/or the width (horizontal flip) of Tdata.
         The probabilities of flipping along height and width can be specified separately.
 
-        Parameters:
+        Args:
             p_height (float, optional): Probability of flipping along the height (vertical flip), in the range [0, 1].
                 Default is 0.5.
             p_width (float, optional): Probability of flipping along the width (horizontal flip), in the range [0, 1].
@@ -61,7 +61,7 @@ class GaussianNoise(RandomThermoTransform):
     def __init__(self, mean: float = 0.0, std: float = 0.1):
         """Initializes the GaussianNoise transformation with specified mean and standard deviation.
 
-        Parameters:
+        Args:
             mean (float): Mean of the Gaussian noise. Default is 0.0.
             std (float): Standard deviation of the Gaussian noise. Default is 1.0.
 

--- a/src/pythermondt/transforms/normalization.py
+++ b/src/pythermondt/transforms/normalization.py
@@ -16,7 +16,7 @@ class MinMaxNormalize(ThermoTransform):
         This is done by subtracting the min value from the data and dividing by the difference between the max and
         min values.
 
-        Parameters:
+        Args:
             eps (float): Small value added to the denominator to avoid division by zero. Default is 1e-12.
         """
         super().__init__()
@@ -48,7 +48,7 @@ class MaxNormalize(ThermoTransform):
     def __init__(self, eps: float = 1e-12):
         """Normalizes the Temperature data (Tdata) in the container to range [0, 1], by using the max value of the data.
 
-        Parameters:
+        Args:
             eps (float): Small value added to the denominator to avoid division by zero. Default is 1e-12.
         """
         super().__init__()
@@ -79,7 +79,7 @@ class ZScoreNormalize(ThermoTransform):
     def __init__(self, eps: float = 1e-12):
         """Normalizes the Temperature data (Tdata) in the container to have mean 0 and standard deviation 1.
 
-        Parameters:
+        Args:
             eps (float): Small value added to the denominator to avoid division by zero. Default is 1e-12.
         """
         super().__init__()

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -63,7 +63,7 @@ class SubtractFrame(ThermoTransform):
     def __init__(self, frame: int = 0):
         """Subtracts 1 frame from all other frames in the Temperature data (Tdata) of the container.
 
-        Parameters:
+        Args:
             frame (int): Frame number that should be subtracted from the Temperature data.
                 Default is the initial frame (frame 0).
         """
@@ -114,7 +114,7 @@ class RemoveFlash(ThermoTransform):
         - "mean_temp_drop": Detect the flash by finding the largest temperature drop in the mean temperature over all
             frames. This is the most reliable method if excitation signal is not available.
 
-        Parameters:
+        Args:
             method (Literal["excitation_signal", "max_temp"]): Method to detect the flash.
                 Default is "excitation_signal".
             offset (int): Offset in frames to add to the detected flash end. Default is 0.
@@ -186,7 +186,7 @@ class CropFrames(ThermoTransform):
     def __init__(self, height: int, width: int, method: Literal["C", "TL", "TR", "BL", "BR"] = "C"):
         """Crops the frames and the mask in the container to the specified height and width.
 
-        Parameters:
+        Args:
             height (int): Height of the cropped frames.
             width (int): Width of the cropped frames.
             method (optional, Literal["C", "TL", "TR", "BL", "BR"]): Cropping strategy. Default is "C" (center).

--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -12,7 +12,7 @@ class SelectFrames(ThermoTransform):
     def __init__(self, frame_indices: int | Sequence[int]):
         """Select a subset of frames from the data container specified by a single index or a list of indices.
 
-        Parameters:
+        Args:
             frame_indices (int | Sequence[int]): Single index or list of indices to select frames.
         """
         super().__init__()
@@ -57,7 +57,7 @@ class SelectFrameRange(ThermoTransform):
     def __init__(self, start: int | None = None, end: int | None = None):
         """Select a range of frames from the data container, by specifying their start and end index.
 
-        Parameters:
+        Args:
             start (int, optional): Start index of the frame range. Default is None, which means the start index is 0.
             end (int, optional): End index of the frame range, which is inclusiv.
                 Default is None, which means the end index is the last frame.
@@ -117,7 +117,7 @@ class NonUniformSampling(ThermoTransform):
         Efficient defect reconstruction from temporal non-uniform pulsed
         thermography data using the virtual wave concept: https://doi.org/10.1016/j.ndteint.2024.103200
 
-        Parameters:
+        Args:
             n_samples (int): Number of samples to select from the original data.
             tau (float, optional): Time shift parameter that controls the non-uniform sampling distribution.
                           If None, will be approxmated automatically using binary search to satisfy

--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -54,7 +54,7 @@ def split_transforms_for_caching(
     Nested Compose transforms are flattened before splitting, so that the
     split is applied to the individual transforms rather than the Compose container itself.
 
-    Parameters:
+    Args:
         transforms (_BaseTransform | Sequence[_BaseTransform]): Transforms to split.
 
     Returns:

--- a/src/pythermondt/writers/base_writer.py
+++ b/src/pythermondt/writers/base_writer.py
@@ -12,7 +12,7 @@ class BaseWriter(ABC):
     def write(self, container: DataContainer, file_name: str):
         """Actual implementation of the writing a single DataContainer to the destination folder.
 
-        Parameters:
+        Args:
             container (DataContainer): The DataContainer which should be written to the destination folder.
             destination_folder (str): The destination folder to write to.
             file_name (str): The name of the DataContainer.

--- a/src/pythermondt/writers/local_writer.py
+++ b/src/pythermondt/writers/local_writer.py
@@ -7,7 +7,7 @@ class LocalWriter(BaseWriter):
     def __init__(self, destination_folder: str):
         """Instantiates a new HDF5Writer.
 
-        Parameters:
+        Args:
             destination_folder (str): The destination folder where the DataContainers should be written to.
         """
         # Verify folder

--- a/src/pythermondt/writers/s3_writer.py
+++ b/src/pythermondt/writers/s3_writer.py
@@ -10,7 +10,7 @@ class S3Writer(BaseWriter):
     def __init__(self, bucket: str, destination_folder: str, boto3_session: boto3.Session | None = None):
         """Instantiates a new HDF5Writer.
 
-        Parameters:
+        Args:
             bucket (str): The name of the bucket to write to.
             destination_folder (str): The destination folder where the DataContainers should be written to.
             boto3_session (boto3.Session, optional): The boto3 session to be used for the S3 client.

--- a/tests/data/datacontainer/test_serialization_ops.py
+++ b/tests/data/datacontainer/test_serialization_ops.py
@@ -17,9 +17,10 @@ def test_serialize_deserialize(
 ):
     """Test serialization and deserialization of DataContainer.
 
-    Parameters:
+    Args:
         container_fixture: Name of the fixture to test
         request: Pytest fixture request object to get the fixture
+        compression: Compression method to use for serialization
 
     Tests:
         1. Serialization to HDF5 bytes
@@ -84,7 +85,7 @@ def test_serialize_invalid_hdf5():
 def test_pickle_serialize_deserialize(container_fixture: str, request: pytest.FixtureRequest):
     """Test that DataContainer can be pickled and unpickled.
 
-    Parameters:
+    Args:
         container_fixture: Name of the fixture to test
         request: Pytest fixture request object to get the fixture
 
@@ -115,7 +116,7 @@ def test_pickle_serialize_deserialize(container_fixture: str, request: pytest.Fi
 def test_pickle_protocols(container_fixture: str, request: pytest.FixtureRequest, protocol: int):
     """Test pickling with different pickle protocols.
 
-    Parameters:
+    Args:
         container_fixture: Name of the fixture to test
         request: Pytest fixture request object to get the fixture
         protocol: Pickle protocol version to test
@@ -141,7 +142,7 @@ def test_pickle_protocols(container_fixture: str, request: pytest.FixtureRequest
 def test_pickle_file_operations(container_fixture: str, request: pytest.FixtureRequest, tmp_path):
     """Test pickle file save and load operations.
 
-    Parameters:
+    Args:
         container_fixture: Name of the fixture to test
         request: Pytest fixture request object to get the fixture
         tmp_path: Pytest temporary directory fixture


### PR DESCRIPTION
This pull request standardizes the documentation of method parameters across multiple files in the `pythermondt` project by replacing the `Parameters` section with `Args` in docstrings. This change improves consistency and aligns with Python's common docstring conventions.

### Standardization of docstring parameter sections:

#### `attribute_ops.py`:
* Replaced `Parameters` with `Args` in all methods, including `add_attribute`, `add_attributes`, `add_unit`, `get_attribute`, `get_attributes`, `get_all_attributes`, `get_unit`, `remove_attribute`, `update_attribute`, `update_attributes`, and `update_unit`. [[1]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL10-R10) [[2]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL24-R24) [[3]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL37-R37) [[4]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL50-R50) [[5]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL66-R66) [[6]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL83-R83) [[7]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL97-R97) [[8]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL118-R118) [[9]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL131-R131) [[10]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL145-R145) [[11]](diffhunk://#diff-9ef3693d35b80b20af4d8e0b73d9c3682baec0eb84619570e7f60fedd0a6e80fL158-R158)

#### `base.py`:
* Updated methods `_path_exists`, `_is_datanode`, `_is_groupnode`, `_is_rootnode`, and `_parent_exists` to use `Args` in docstrings. [[1]](diffhunk://#diff-d1048ba4909810e1c07b9940b5aaaf80b4e786a135d9fe1c7117eeccfd70acfcL167-R167) [[2]](diffhunk://#diff-d1048ba4909810e1c07b9940b5aaaf80b4e786a135d9fe1c7117eeccfd70acfcL182-R182) [[3]](diffhunk://#diff-d1048ba4909810e1c07b9940b5aaaf80b4e786a135d9fe1c7117eeccfd70acfcL197-R197) [[4]](diffhunk://#diff-d1048ba4909810e1c07b9940b5aaaf80b4e786a135d9fe1c7117eeccfd70acfcL212-R212) [[5]](diffhunk://#diff-d1048ba4909810e1c07b9940b5aaaf80b4e786a135d9fe1c7117eeccfd70acfcL229-R229)

#### `core.py`:
* Standardized docstrings for `__init__` and `__eq__` methods by replacing `Parameters` with `Args`. [[1]](diffhunk://#diff-878b8b613af55400825cce83c0079042a1a52761eb959d4755225ed7cdb73104L29-R29) [[2]](diffhunk://#diff-878b8b613af55400825cce83c0079042a1a52761eb959d4755225ed7cdb73104L62-R62)

#### `dataset_ops.py`:
* Applied the change to methods such as `add_dataset`, `add_datasets`, `get_dataset`, `get_datasets`, `remove_dataset`, `update_dataset`, and `update_datasets`. [[1]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL14-R14) [[2]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL37-R37) [[3]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL52-R52) [[4]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL67-R67) [[5]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL99-R99) [[6]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL113-R113) [[7]](diffhunk://#diff-b3dd11b4a9327cd2c4e59ea7a2ea8945b3537f7eb279930c0be4713b74efc52fL129-R129)

#### `group_ops.py`:
* Updated `add_group` and `remove_group` methods to use `Args` in docstrings. [[1]](diffhunk://#diff-8ceb20b86782073ccb1ed454636c8b531c7cb4c08ee612509aee4b2390573976L10-R10) [[2]](diffhunk://#diff-8ceb20b86782073ccb1ed454636c8b531c7cb4c08ee612509aee4b2390573976L32-R32)

#### `serialization_ops.py`:
* Standardized docstrings for methods such as `serialize_to_hdf5`, `_add_attributes`, `save_to_hdf5`, `deserialize`, `_process_group`, and `_process_dataset`. [[1]](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L21-R21) [[2]](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L71-R71) [[3]](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L86-R86) [[4]](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L102-R102) [[5]](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L135-R135) [[6]](diffhunk://#diff-37c325e524a82493eba7e95fb528c3db387e4f707b2825d7181a9afa95924a03L161-R161)