### PR TITLE
Update the post release workflow to include publishing the package

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v6.4.3
         with:
-          version-file: requirements_dev.txt
           enable-cache: false
 
       - name: Publish the package


### PR DESCRIPTION
This pull request adds a new job to the GitHub Actions workflow to automate publishing the package after a release. The new job downloads the built wheel file from the GitHub release, sets up the publishing environment, and then publishes the package to the configured repository.

**Automation for package publishing:**

* Added a `publish-package` job to `.github/workflows/post_release.yml` that downloads the wheel file from the GitHub release, sets up the `uv` tool, and publishes the package to the specified repository using secrets for authentication.