### PR TITLE
Fix bug in automatic tau calculation of NonUniformSampling that caused higher tau values than needed

### DIFF
--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -177,10 +177,9 @@ class NonUniformSampling(ThermoTransform):
         # Calculate tau using binary search if not provided
         n_samples_original = len(domain_values)
         t_end = domain_values[-1]
+        dt_min = domain_values[1] - domain_values[0]  # Assuming the input data is uniformly sampled
         if not self.tau:
-            tau = torch.tensor(
-                self._calculate_tau(t_end.item(), domain_values[1].item() - domain_values[0].item(), self.n_samples),
-            )
+            tau = torch.tensor(self._calculate_tau(t_end.item(), dt_min.item(), self.n_samples))
         else:
             tau = torch.tensor(self.tau)
 


### PR DESCRIPTION
- Fix tau calculation logic to use the requested `n_samples` (`Nt`) instead of the original number of samples
- Add `precision` parameter to control the binary search accuracy
- Add a validation step to ensure the computed tau meets the minimum time step constraint
- Raise an error if the binary search fails to find a valid tau

This fixes an issue where using the original sample count led to overestimated tau values in the NonUniformSampling transform.
