### PR TITLE
Refactor container_collate to remove inner function and fix pickling issues in multi-threading

### DIFF
--- a/src/pythermondt/dataset/utils.py
+++ b/src/pythermondt/dataset/utils.py
@@ -126,6 +126,7 @@ def container_collate(*paths: str) -> Callable[[Sequence[DataContainer]], tuple[
     return partial(_container_collate_impl, paths=paths)
 
 
+def _container_collate_impl(batch: Sequence[DataContainer], paths: tuple[str, ...]) -> tuple[torch.Tensor, ...]:
     """Implementation function that processes a batch of DataContainer objects for collation.
 
     Args:


### PR DESCRIPTION
- Removed the inner `collate_fn` function from `container_collate`
- Introduced `_container_collate_impl` as a top-level function
- Used `functools.partial` to return a callable with bound `paths` argument

This change avoids issues with pickling local functions when using multi-threading, improving compatibility with data loaders and multiprocessing workflows.
