### PR TITLE
Pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: '^(examples/|docs/pyreverse/)'
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
         # Check and fix common formatting issues
     -   id: trailing-whitespace
@@ -19,19 +19,18 @@ repos:
         args: [--maxkb=1024] # Allow files up to 1MB
         exclude: tests/assets/.*
 
-
         # Security checks
     -   id: detect-private-key
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.4
+    rev: v0.12.12
     hooks:
     -   id: ruff-check
         args: [--fix]
     -   id: ruff-format
 
 -   repo: https://github.com/crate-ci/typos
-    rev: v1.34.0
+    rev: v1.36.2
     hooks:
       - id: typos
         args: [.github, ., -w]


### PR DESCRIPTION
This pull request updates several dependencies in the `.pre-commit-config.yaml` file to their latest versions, ensuring that our pre-commit hooks use the most recent features and fixes.

Dependency version upgrades:

* Upgraded `pre-commit-hooks` from `v5.0.0` to `v6.0.0` for improved formatting checks and reliability.
* Upgraded `ruff-pre-commit` from `v0.12.4` to `v0.12.12` to benefit from the latest linting and formatting improvements.
* Upgraded `typos` from `v1.34.0` to `v1.36.2` for enhanced typo detection.