### PR TITLE
Add support for disabling compression in HDF5 serialization

### DIFF
--- a/src/pythermondt/data/datacontainer/serialization_ops.py
+++ b/src/pythermondt/data/datacontainer/serialization_ops.py
@@ -17,7 +17,7 @@ CompressionType: TypeAlias = Literal["lzf", "gzip", "none"]
 
 
 class SerializationOps(BaseOps):
-    def serialize_to_hdf5(self, compression: CompressionType = "lzf", compression_opts: int = 4) -> BytesIO:
+    def serialize_to_hdf5(self, compression: CompressionType = "lzf", compression_opts: int | None = 4) -> BytesIO:
         """Serializes the DataContainer instance to an HDF5 file.
 
         Args:
@@ -82,7 +82,7 @@ class SerializationOps(BaseOps):
             # Assign attribute to HDF5 object
             h5obj.attrs[key] = value
 
-    def save_to_hdf5(self, path: str, compression: CompressionType = "lzf", compression_opts: int = 4):
+    def save_to_hdf5(self, path: str, compression: CompressionType = "lzf", compression_opts: int | None = 4):
         """Saves the serialized DataContainer to an HDF5 file at the specified path.
 
         Args:

--- a/tests/data/datacontainer/test_serialization_ops.py
+++ b/tests/data/datacontainer/test_serialization_ops.py
@@ -17,7 +17,7 @@ def test_serialize_deserialize(
     container_fixture: str,
     request: pytest.FixtureRequest,
     compression: Literal["gzip", "lzf", "none"],
-    compression_opts: int,
+    compression_opts: int | None,
 ):
     """Test serialization and deserialization of DataContainer.
 
@@ -56,7 +56,7 @@ def test_serialize_file_operations(
     container_fixture: str,
     request: pytest.FixtureRequest,
     compression: Literal["gzip", "lzf", "none"],
-    compression_opts: int,
+    compression_opts: int | None,
     tmp_path,
 ):
     """Test save_to_hdf5 and load_from_hdf5 file operations."""


### PR DESCRIPTION
- Extend `CompressionType` to include `"none"` as a valid option
- Update `serialize_to_hdf5` and `save_to_hdf5` to handle no compression
- Adjust docstrings to document the new `"none"` option
- Update tests to parametrize with `"none"` compression and validate behavior
- Ensure `compression_opts` is properly handled depending on method

This change allows users to disable compression for faster read/write operations at the cost of larger file sizes. Tests are updated to cover the new case and ensure consistency.
