### PR TITLE
Add reversed iteration support to BaseReader

### DIFF
--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -165,7 +165,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
     def __iter__(self) -> Iterator[DataContainer]:
         # Take a snapshot of the file list ==> to avoid undefined behavior when the file list changes during iteration
-        # and caching is of
+        # and caching is off
         file_paths = self.files
 
         for file in file_paths:


### PR DESCRIPTION
- Implement `__reversed__` method in `BaseReader` to allow reverse iteration over files
- Ensure snapshot of `self.files` is taken before iteration to prevent issues when caching is off

Adds reverse iteration capability to `BaseReader`, enabling consistent and safe backward traversal of file sequences.
