### PR TITLE
Fix circular import error when loading plugins in some cases by lazily building parser registry

### DIFF
--- a/src/pythermondt/io/parsers/__init__.py
+++ b/src/pythermondt/io/parsers/__init__.py
@@ -21,14 +21,11 @@ def _load_parser_plugins() -> tuple[type[BaseParser], ...]:
 
 @lru_cache(maxsize=1)
 def _get_registry() -> tuple[type[BaseParser], ...]:
-    """
-    Lazily build and cache the parser registry on first use.
+    """Lazily build and cache the parser registry on first use.
 
-    This function constructs the registry of available parser classes, including both
-    built-in and plugin parsers, only when it is first called. The result is cached
-    using functools.lru_cache (with maxsize=1), so subsequent calls return the same
-    registry instance without rebuilding. This replaces previous module-level initialization
-    and ensures that plugin discovery is performed only once per process.
+    Constructs the registry of built-in and plugin parsers only when first called.
+    The result is cached so subsequent calls return the same registry instance. A tuple of parser classes is returned,
+    ensuring immutability and thread safety, exactly as the previous module level CONSTANT list did.
     """
     builtins = (HDF5Parser, SimulationParser, EdevisParser)
     plugins = _load_parser_plugins()


### PR DESCRIPTION
- Refactor parser registry to use lazy initialization with `@lru_cache`
- Build registry only on first call instead of at import time
- Return immutable tuple of parsers instead of mutable list
- Ensure `_load_parser_plugins` returns a tuple for consistency

This fixes a circular import error that could prevent plugin parsers from loading in some cases.  
By lazily building the parser registry on first call, plugins can be loaded reliably without triggering partial initialization errors.  
The registry is now immutable, making it safer and preventing accidental mutations.
