### PR TITLE
Remove time-domain restriction from SelectFrames and SelectFrameRange

### DIFF
--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -30,7 +30,7 @@ class SelectFrames(ThermoTransform):
 
         # Check if tdata has a "frame" dimension (last axis)
         if tdata.ndim < 3:
-            raise ValueError("SelectFrameRange transform requires tdata to have at least 3 dimensions (H, W, Frames).")
+            raise ValueError("SelectFrames transform requires tdata to have at least 3 dimensions (H, W, Frames).")
 
         # Select Frames
         tdata = tdata[..., self.frame_indices]


### PR DESCRIPTION
- Remove `quantity == "time"` validation from both `SelectFrames` and `SelectFrameRange`
- Retain index bounds checks (`frame_indices`, `start`, `end`)
- Keep requirement that `tdata` has at least 3 dimensions (H, W, Frames)
- Preserve selection logic; `end` remains inclusive

This relaxes the transforms to work with non-time domains (e.g., frequency, VWC transform, etc.) while maintaining shape and index safety checks.
