### PR TITLE
Apply pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,14 +23,14 @@ repos:
     -   id: detect-private-key
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
+    rev: v0.14.0
     hooks:
     -   id: ruff-check
         args: [--fix]
     -   id: ruff-format
 
 -   repo: https://github.com/crate-ci/typos
-    rev: v1.36.2
+    rev: v1.38.1
     hooks:
       - id: typos
         args: [.github, ., -w]

--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -120,7 +120,7 @@ class NonUniformSampling(ThermoTransform):
         Args:
             n_samples (int): Number of samples to select from the original data.
             tau (float, optional): Time shift parameter that controls the non-uniform sampling distribution.
-                If None, will be approxmated automatically using binary search to satisfy the minimum time step
+                If None, will be approximated automatically using binary search to satisfy the minimum time step
                 constraint from Equation (25) of the paper. Default is None.
             interpolate (bool, optional): Whether to apply interpolation after non-uniform sampling. If True,
                 the downsampled data will be interpolated to match the exact time steps calculated according to


### PR DESCRIPTION
This pull request updates dependencies and fixes a minor typo in a docstring. The most important changes are:

Dependency updates:

* Updated `ruff-pre-commit` hook in `.pre-commit-config.yaml` from version `v0.12.12` to `v0.14.0`, ensuring the latest linting and formatting improvements are used.
* Updated `typos` hook in `.pre-commit-config.yaml` from version `v1.36.2` to `v1.38.1`, providing improved typo detection.

Documentation improvements:

* Fixed a spelling error in the docstring for `tau` in the `__init__` method of `src/pythermondt/transforms/sampling.py` ("approxmated" → "approximated").