### PR TITLE
Set cache dependcy glob to resolve warning on publish

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v7.1.0
         with:
+          cache-dependency-glob: ${{ vars.CACHE_DEPENDENCY_GLOB }}
           save-cache: false
 
       - name: Publish the package


### PR DESCRIPTION
This pull request makes a minor configuration update to the GitHub Actions workflow for post-release jobs. The change improves caching behavior by specifying a dependency glob pattern.

* Workflow configuration: Added `cache-dependency-glob` to the `Setup uv` step in `.github/workflows/post_release.yml` to use the value from `${{ vars.CACHE_DEPENDENCY_GLOB }}` for more precise dependency caching.