### PR TITLE
Remove deprecated Ruff rule UP038 from configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ select = [
 fixable = ["ALL"]
 pydocstyle.convention = "google"
 ignore = [
-    "UP038", # Use X | Y in {} call instead of (X, Y) ==> Ignore for performance reasons, see: https://github.com/astral-sh/ruff/issues/7871
     "D100",   # Missing docstring in public module
     "D101",   # Missing docstring in public class
     "D102",   # Missing docstring in public method


### PR DESCRIPTION
- Remove UP038 from ignored Ruff rules in `pyproject.toml`
- Align configuration with Ruff 0.10 deprecation of UP038
- Resolve warnings raised by `ruff check` and `ruff format`

This change eliminates deprecated rule warnings during linting and formatting, ensuring compatibility with the latest Ruff version.


Refs: https://github.com/astral-sh/ruff/pull/16681