### PR TITLE
Add cache release and Manager shutdown to prevent dangling processes in lazy cache mode

### DIFF
--- a/src/pythermondt/dataset/base.py
+++ b/src/pythermondt/dataset/base.py
@@ -218,7 +218,8 @@ class BaseDataset(Dataset, ABC):
         try:
             if isinstance(self.__cache, ListProxy):
                 self.__cache[:] = []
-            self.__cache = []
+            else:
+                self.__cache = []
             self.__det_transforms = None
             self.__runtime_transforms = None
             self.__cache_built = False


### PR DESCRIPTION
- Add `__manager: SyncManager | None` to track multiprocessing manager lifecycle
- Store a single `Manager()` instance in `build_cache()` and use `self.__manager.list(...)` for lazy cache
- Implement `release_cache(gc_collect: bool = True)` to clear `ListProxy`/list, reset transforms/flags, and shut down the manager
- Call `release_cache()` from `__del__` to ensure cleanup on dataset deletion
- Minor cleanup and Ruff formatting

This change ensures that lazy cache mode does not leave background manager processes running. By centralizing cache teardown in `release_cache()` and invoking it from the dataset destructor, memory is freed promptly and multiprocessing resources are properly terminated.
