### PR TITLE
Add new interpolation method "averaging"

### DIFF
--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -106,9 +106,15 @@ class SelectFrameRange(ThermoTransform):
 class NonUniformSampling(ThermoTransform):
     """Implement a non-uniform sampling strategy for the data container.
 
-    The implementation is based on the following paper:
-    Efficient defect reconstruction from temporal non-uniform pulsed
-    thermography data using the virtual wave concept: https://doi.org/10.1016/j.ndteint.2024.103200
+    Based on: *Efficient defect reconstruction from temporal non-uniform pulsed thermography data using the virtual
+    wave concept* — https://doi.org/10.1016/j.ndteint.2024.103200
+
+    The following interpolation methods are supported:
+        - **nearest** Find the closest time steps in the original data using ``torch.searchsorted``.
+        - **linear** Apply linear interpolation to match the exact time steps calculated according to Equation (6)
+            of the paper.
+        - **averaging** Bin the original data into exponentially spaced intervals and average within each bin to reduce
+            aliasing. Excitation signal is still linearly interpolated to preserve its shape.
     """
 
     def __init__(
@@ -120,24 +126,25 @@ class NonUniformSampling(ThermoTransform):
     ):
         """Implement a non-uniform sampling strategy for the data container.
 
-        The implementation is based on the following paper:
-        Efficient defect reconstruction from temporal non-uniform pulsed
-        thermography data using the virtual wave concept: https://doi.org/10.1016/j.ndteint.2024.103200
+        Based on: *Efficient defect reconstruction from temporal non-uniform pulsed thermography data using the virtual
+        wave concept* — https://doi.org/10.1016/j.ndteint.2024.103200
+
+        The following interpolation methods are supported:
+        - **nearest** Find the closest time steps in the original data using ``torch.searchsorted``.
+        - **linear** Apply linear interpolation to match the exact time steps calculated according to Equation (6)
+            of the paper.
+        - **averaging** Bin the original data into exponentially spaced intervals and average within each bin to reduce
+            aliasing. Excitation signal is still linearly interpolated to preserve its shape.
 
         Args:
             n_samples (int): Number of samples to select from the original data.
-            tau (float, optional): Time shift parameter that controls the non-uniform sampling distribution.
-            If None, will be automatically calculated using binary search to satisfy the minimum time step
-            constraint from Equation (25) of the paper. Default is None.
-            interpolate (str, optional): Interpolation method to use after non-uniform sampling. Options are:
-            - "nearest": Find the closest time steps in the original data using torch.searchsorted.
-            - "linear": Apply linear interpolation to match the exact time steps calculated according to
-              Equation (6) of the paper.
-            - "averaging": Bin the original data into exponentially spaced intervals and average within
-              each bin to reduce aliasing. Excitation signal is still linearly interpolated to preserve its shape.
-            Default is "linear".
+            tau (float, optional): Time shift parameter that controls the non-uniform sampling distribution. If None,
+                will be automatically calculated using binary search to satisfy the minimum time step constraint from
+                Equation (25) of the paper. Default is None.
+            interpolate (Literal["nearest", "linear", "averaging"], optional): Interpolation method to use after
+                non-uniform sampling. Default is ``"linear"``.
             precision (float, optional): Precision used for the binary search when automatically calculating tau.
-            Default is 1e-2, which is sufficient for most applications.
+                Default is 1e-2, which is sufficient for most applications.
         """
         super().__init__()
         self.n_samples = n_samples


### PR DESCRIPTION
- Introduce `"averaging"` strategy: bin domain into exponentially spaced intervals and average per bin to reduce aliasing and improve SNR
- Change `interpolate` from `bool` → `Literal["nearest", "linear", "averaging"]` (default: `"linear"`)
- Always linearly interpolate the excitation signal to preserve its shape
- Add `_average_binned` using `torch.bucketize` + one-hot matmul for vectorized binning
- Rename `_interp_vectorized` → `_interp_vect`; refactor `forward` to `match` on interpolation mode
- Update docstrings and parameter descriptions; minor naming/style cleanups (ruff)

**Summary**
This PR extends `NonUniformSampling` with an `"averaging"` post-processing option that bins original samples around target exponential time steps and averages within each bin. This reduces aliasing and typically yields better SNR compared to nearest/linear sampling, while keeping the excitation signal linearly interpolated to maintain its waveform. The API now accepts a string for `interpolate`:

- `True` (old) ↔ `"linear"`  
- `False` (old) ↔ `"nearest"`  
- New option: `"averaging"`

This is a small breaking change for callers passing a boolean; switch to the corresponding string to maintain previous behavior.

**Explanation:**
<img width="1162" height="622" alt="grafik" src="https://github.com/user-attachments/assets/6f49a5ee-abaf-4362-b9eb-1f332ec2d830" />

**SNR-Comparisons:**
<img width="5037" height="3751" alt="interpolation_snr_boxplots" src="https://github.com/user-attachments/assets/66fdca8d-8d69-4f0a-aad7-5cdd2f583b06" />


<img width="5038" height="3751" alt="interpolation_snr_over_frames" src="https://github.com/user-attachments/assets/bbc7d294-d3c4-4e8b-b196-601acf46c987" />
