### PR TITLE
Fix FileNotFoundError during dataset cleanup on Windows when using lazy cache mode

### DIFF
--- a/src/pythermondt/dataset/base.py
+++ b/src/pythermondt/dataset/base.py
@@ -225,7 +225,7 @@ class BaseDataset(Dataset, ABC):
         if self.__manager:
             try:
                 self.__manager.shutdown()
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 pass
             finally:
                 self.__manager = None


### PR DESCRIPTION
This pull request refines the cache release logic in the `release_cache` method within `src/pythermondt/dataset/base.py`. The update simplifies how cached items are cleared and improves the robustness of manager shutdown handling.

Cache management improvements:
* Only regular lists are now explicitly cleared; `ListProxy` objects are left to be handled by manager shutdown, reducing unnecessary operations and potential errors.

Manager shutdown robustness:
* The manager shutdown process is now wrapped in a try-except block to safely handle any exceptions, ensuring that the manager is always set to `None` even if shutdown fails.