### PR TITLE
Fix typing for transforms in some dataset classes

### DIFF
--- a/src/pythermondt/dataset/indexed_thermo_dataset.py
+++ b/src/pythermondt/dataset/indexed_thermo_dataset.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterator, Sequence
 
 from ..data import DataContainer
-from ..transforms import ThermoTransform
+from ..transforms.base import _BaseTransform
 from .base import BaseDataset
 
 
@@ -14,13 +14,13 @@ class IndexedThermoDataset(BaseDataset):
     IndexedThermoDataset maintains the transform chain of the parent dataset and appends the additional transform to it.
     """
 
-    def __init__(self, dataset: BaseDataset, indices: Sequence[int], transform: ThermoTransform | None = None):
+    def __init__(self, dataset: BaseDataset, indices: Sequence[int], transform: _BaseTransform | None = None):
         """Initialize an indexed dataset with optional additional transform.
 
         Args:
             dataset (ThermoDataset): Parent dataset to index into
             indices (Sequence[int]): Sequence of indices to select from parent
-            transform (ThermoTransform, optional): Optional transform to apply after parent's transform
+            transform (_BaseTransform, optional): Optional transform to apply after parent's transform
 
         Raises:
             IndexError: If any of the provided indices are out of range

--- a/src/pythermondt/dataset/utils.py
+++ b/src/pythermondt/dataset/utils.py
@@ -7,7 +7,7 @@ import torch
 from torch import Generator, default_generator
 
 from ..data import DataContainer
-from ..transforms import ThermoTransform
+from ..transforms.base import _BaseTransform
 from .indexed_thermo_dataset import IndexedThermoDataset
 from .thermo_dataset import ThermoDataset
 
@@ -15,7 +15,7 @@ from .thermo_dataset import ThermoDataset
 def random_split(
     dataset: ThermoDataset,
     lengths: Sequence,
-    transforms: Sequence[ThermoTransform | None] | None = None,
+    transforms: Sequence[_BaseTransform | None] | None = None,
     generator: Generator = default_generator,
 ) -> list[IndexedThermoDataset]:
     """Split a dataset into random non-overlapping subsets of given lengths with optional transforms being applied.
@@ -29,7 +29,7 @@ def random_split(
     Args:
         dataset (Dataset): Dataset to be split
         lengths (Sequence[float]): Fractions for each split that sum up to 1.0.
-        transforms (Sequence[ThermoTransform | None], optional): Optional sequence of transforms for each split.
+        transforms (Sequence[_BaseTransform | None], optional): Optional sequence of transforms for each split.
         generator (Generator, optional): Generator used for reproducible splits.
             Per default the default generator is used.
 


### PR DESCRIPTION
This pull request updates type annotations and import statements to use the more general `_BaseTransform` type instead of the specific `ThermoTransform` type in the dataset modules. This change improves flexibility and consistency in how transforms are handled across the codebase.

**Type annotation and import updates:**

* Changed imports in `indexed_thermo_dataset.py` and `utils.py` to import `_BaseTransform` from `transforms.base` instead of `ThermoTransform` from `transforms` to generalize transform handling. [[1]](diffhunk://#diff-6c0bb65a5e22ccf535bd74aa9239743603089c69c0e42ffbe986df463e7f2769L4-R4) [[2]](diffhunk://#diff-f6d4638b7da4d4dbfe05a0a38f5a1a67e40eb25f2a92bff399d9ca1e456e516dL10-R18)
* Updated type annotations for the `transform` parameter in `IndexedThermoDataset.__init__` and for the `transforms` parameter in `random_split` to use `_BaseTransform` instead of `ThermoTransform`. [[1]](diffhunk://#diff-6c0bb65a5e22ccf535bd74aa9239743603089c69c0e42ffbe986df463e7f2769L17-R23) [[2]](diffhunk://#diff-f6d4638b7da4d4dbfe05a0a38f5a1a67e40eb25f2a92bff399d9ca1e456e516dL32-R32)