### PR TITLE
Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
       url: ${{ inputs.environment == 'pypi' && 'https://pypi.org/p/pythermondt' || 'https://test.pypi.org/p/pythermondt' }}
     permissions:
       id-token: write  # Mandatory for trusted publishing
+      contents: read   # Required for actions/checkout
     steps:
       # Step 1: Checkout code
       - name: Checkout code
@@ -39,6 +40,7 @@ jobs:
         with:
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
           save-cache: false
+          version-file: requirements_dev.txt
 
       # Step 3: Build package
       - name: Build package
@@ -48,4 +50,4 @@ jobs:
       - name: Publish package distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ inputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' }}
+          repository-url: ${{ inputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for publishing the Python package to either PyPI or TestPyPI. The workflow supports both manual and reusable invocation, and includes steps for checking out the code, setting up the environment, building the package, and publishing it.

**New publishing workflow:**

* Added `.github/workflows/publish.yml` to automate publishing the package to PyPI or TestPyPI, supporting both manual (`workflow_dispatch`) and reusable (`workflow_call`) triggers.
* The workflow includes steps to check out the code, set up the environment with the specified Python version, build the package using `uv`, and publish it using trusted publishing via `pypa/gh-action-pypi-publish`.