### PR TITLE
Add typed backend client options for Azure Blob and S3 storage backends

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,8 +176,8 @@ disable = [
 [tool.pylint.design]
 max-parents = 12 # Increase because mixin classes have more parents
 min-public-methods = 1 # Set to 1 because static parser classes have only 1 public method
-max-args = 10 # Some Reader classes have many arguments to configure
-max-positional-arguments = 10 # Some Reader classes require many positional arguments to configure
+max-args = 12 # Some Reader classes have many arguments to configure
+max-positional-arguments = 12 # Some Reader classes require many positional arguments to configure
 
 # typos
 [tool.typos]

--- a/src/pythermondt/io/__init__.py
+++ b/src/pythermondt/io/__init__.py
@@ -1,9 +1,10 @@
-from .backends import AzureBlobBackend, BaseBackend, LocalBackend, S3Backend
+from .backends import AzureBlobBackend, AzureBlobClientOptions, BaseBackend, LocalBackend, S3Backend, S3ClientOptions
 from .parsers import BaseParser, EdevisParser, HDF5Parser, SimulationParser
 from .utils import IOPathWrapper
 
 __all__ = [
     "AzureBlobBackend",
+    "AzureBlobClientOptions",
     "BaseBackend",
     "BaseParser",
     "EdevisParser",
@@ -11,5 +12,6 @@ __all__ = [
     "IOPathWrapper",
     "LocalBackend",
     "S3Backend",
+    "S3ClientOptions",
     "SimulationParser",
 ]

--- a/src/pythermondt/io/backends/__init__.py
+++ b/src/pythermondt/io/backends/__init__.py
@@ -1,6 +1,14 @@
 from .azure_backend import AzureBlobBackend
 from .base_backend import BaseBackend
 from .local_backend import LocalBackend
+from .options import AzureBlobClientOptions, S3ClientOptions
 from .s3_backend import S3Backend
 
-__all__ = ["AzureBlobBackend", "BaseBackend", "LocalBackend", "S3Backend"]
+__all__ = [
+    "AzureBlobBackend",
+    "AzureBlobClientOptions",
+    "BaseBackend",
+    "LocalBackend",
+    "S3Backend",
+    "S3ClientOptions",
+]

--- a/src/pythermondt/io/backends/azure_backend.py
+++ b/src/pythermondt/io/backends/azure_backend.py
@@ -10,6 +10,7 @@ from tqdm.auto import tqdm
 
 from ..utils import IOPathWrapper
 from .base_backend import BaseBackend
+from .options import AzureBlobClientOptions
 from .progress import TqdmCallback, get_tqdm_default_kwargs
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class AzureBlobBackend(BaseBackend):
         prefix: str = "",
         connection_string: str | None = None,
         credential: TokenCredential | None = None,
+        client_options: AzureBlobClientOptions | None = None,
     ) -> None:
         """Initialize Azure Blob Storage backend.
 
@@ -40,15 +42,18 @@ class AzureBlobBackend(BaseBackend):
             prefix (str, optional): Prefix within the specified container
             connection_string (str, optional): Connection string (optional, for dev/researchers)
             credential (TokenCredential, optional): Azure TokenCredential (optional, defaults to DefaultAzureCredential)
+            client_options (AzureBlobClientOptions | None): Optional Azure client tuning options.
         """
+        client_kwargs = client_options.as_kwargs() if client_options else {}
+
         if connection_string:
-            self.__client = BlobServiceClient.from_connection_string(connection_string)
+            self.__client = BlobServiceClient.from_connection_string(connection_string, **client_kwargs)
             logger.debug("Client initialized using connection string.")
         else:
             if credential is None:
                 credential = DefaultAzureCredential()
                 logger.debug("Using DefaultAzureCredential for authentication.")
-            self.__client = BlobServiceClient(account_url, credential=credential)
+            self.__client = BlobServiceClient(account_url, credential=credential, **client_kwargs)
 
         self.__container_name = container_name
         self.__prefix = prefix

--- a/src/pythermondt/io/backends/azure_backend.py
+++ b/src/pythermondt/io/backends/azure_backend.py
@@ -58,7 +58,12 @@ class AzureBlobBackend(BaseBackend):
         self.__container_name = container_name
         self.__prefix = prefix
 
-        logger.debug("AzureBlobBackend(container=%s, prefix=%s) initialized.", container_name, prefix)
+        logger.debug(
+            "AzureBlobBackend initialized: container=%s, prefix=%s, client_options=%s",
+            container_name,
+            prefix,
+            client_options or "default",
+        )
 
     @property
     def remote_source(self) -> bool:

--- a/src/pythermondt/io/backends/options.py
+++ b/src/pythermondt/io/backends/options.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, fields
+
+
+@dataclass(slots=True, frozen=True)
+class BackendClientOptions:
+    """Shared helpers for backend client option dataclasses."""
+
+    def as_kwargs(self) -> dict[str, object]:
+        """Return only configured client kwargs."""
+        return {field.name: value for field in fields(self) if (value := getattr(self, field.name)) is not None}
+
+
+@dataclass(slots=True, frozen=True)
+class AzureBlobClientOptions(BackendClientOptions):
+    """Azure Blob Storage client tuning options."""
+
+    max_single_put_size: int | None = None
+    max_block_size: int | None = None
+    connection_timeout: int | None = None
+    read_timeout: int | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class S3ClientOptions(BackendClientOptions):
+    """S3 client tuning options."""
+
+    connect_timeout: int | float | None = None
+    read_timeout: int | float | None = None
+    max_pool_connections: int | None = None

--- a/src/pythermondt/io/backends/options.py
+++ b/src/pythermondt/io/backends/options.py
@@ -1,11 +1,12 @@
 from dataclasses import dataclass, fields
+from typing import Any
 
 
 @dataclass(slots=True, frozen=True)
 class BackendClientOptions:
     """Shared helpers for backend client option dataclasses."""
 
-    def as_kwargs(self) -> dict[str, object]:
+    def as_kwargs(self) -> dict[str, Any]:
         """Return only configured client kwargs."""
         return {field.name: value for field in fields(self) if (value := getattr(self, field.name)) is not None}
 

--- a/src/pythermondt/io/backends/s3_backend.py
+++ b/src/pythermondt/io/backends/s3_backend.py
@@ -3,29 +3,43 @@ from io import BytesIO
 from urllib.parse import urlparse
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from ..utils import IOPathWrapper
 from .base_backend import BaseBackend
+from .options import S3ClientOptions
 from .progress import TqdmCallback
 
 logger = logging.getLogger(__name__)
 
 
 class S3Backend(BaseBackend):
-    def __init__(self, bucket: str, prefix: str, session: boto3.Session | None = None) -> None:
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str,
+        session: boto3.Session | None = None,
+        client_options: S3ClientOptions | None = None,
+    ) -> None:
         # Use default boto3 session if none is provided
         if not session:
             logger.debug("No boto3 session provided, creating default session.")
             session = boto3.Session()
 
         # Create a new s3 client from the given session
-        self.__client = session.client("s3")
+        config = Config(**client_options.as_kwargs()) if client_options else None
+        self.__client = session.client("s3", config=config)
 
         # Write the bucket and prefix to the private attributes
         self.__bucket = bucket
         self.__prefix = prefix
-        logger.debug("S3Backend(bucket=%s, prefix=%s) initialized.", bucket, prefix)
+        logger.debug(
+            "S3Backend initialized: bucket=%s, prefix=%s, client_options=%s",
+            bucket,
+            prefix,
+            client_options or "default",
+        )
 
     @property
     def remote_source(self) -> bool:

--- a/src/pythermondt/readers/azure_reader.py
+++ b/src/pythermondt/readers/azure_reader.py
@@ -1,6 +1,6 @@
 from azure.core.credentials import TokenCredential
 
-from ..io import AzureBlobBackend, BaseParser
+from ..io import AzureBlobBackend, AzureBlobClientOptions, BaseParser
 from .base_reader import BaseReader
 
 
@@ -12,6 +12,7 @@ class AzureBlobReader(BaseReader):
         prefix: str,
         connection_string: str | None = None,
         credential: TokenCredential | None = None,
+        client_options: AzureBlobClientOptions | None = None,
         num_files: int | None = None,
         download_files: bool = False,
         cache_files: bool = True,
@@ -28,6 +29,7 @@ class AzureBlobReader(BaseReader):
             prefix (str): Prefix (folder path) within container
             connection_string (str | None): Optional connection string (overrides default auth)
             credential (TokenCredential | None): Optional Azure TokenCredential (overrides default auth)
+            client_options (AzureBlobClientOptions | None): Optional Azure client tuning options.
             num_files (int | None): Maximum number of files to read. If None, reads all files.
             download_files (bool): If True, downloads and caches files locally during operations.
                 If False, files are accessed on-demand without local caching. Default: False.
@@ -42,6 +44,7 @@ class AzureBlobReader(BaseReader):
         self.__connection_string = connection_string
         self.__account_url = account_url
         self.__credential = credential
+        self.__client_options = client_options
 
     def _create_backend(self) -> AzureBlobBackend:
         """Create a new AzureBlobBackend instance.
@@ -54,6 +57,7 @@ class AzureBlobReader(BaseReader):
             prefix=self.__prefix,
             connection_string=self.__connection_string,
             credential=self.__credential,
+            client_options=self.__client_options,
         )
 
     def _get_reader_params(self) -> str:

--- a/src/pythermondt/readers/azure_reader.py
+++ b/src/pythermondt/readers/azure_reader.py
@@ -5,6 +5,7 @@ from .base_reader import BaseReader
 
 
 class AzureBlobReader(BaseReader):
+    # pylint: disable=duplicate-code
     def __init__(
         self,
         account_url: str,

--- a/src/pythermondt/readers/s3_reader.py
+++ b/src/pythermondt/readers/s3_reader.py
@@ -5,6 +5,7 @@ from .base_reader import BaseReader
 
 
 class S3Reader(BaseReader):
+    # pylint: disable=duplicate-code
     def __init__(
         self,
         bucket: str,

--- a/src/pythermondt/readers/s3_reader.py
+++ b/src/pythermondt/readers/s3_reader.py
@@ -1,6 +1,6 @@
 import boto3
 
-from ..io import BaseParser, S3Backend
+from ..io import BaseParser, S3Backend, S3ClientOptions
 from .base_reader import BaseReader
 
 
@@ -11,6 +11,7 @@ class S3Reader(BaseReader):
         prefix: str,
         region_name: str | None = None,
         profile_name: str | None = None,
+        client_options: S3ClientOptions | None = None,
         num_files: int | None = None,
         download_files: bool = False,
         cache_files: bool = True,
@@ -29,6 +30,7 @@ class S3Reader(BaseReader):
                 Default is None, which uses the default region from the AWS configuration.
             profile_name (str, optional): The AWS profile name to use for authentication. Default is None, which uses
                 the default profile from the AWS configuration.
+            client_options (S3ClientOptions | None): Optional S3 client tuning options.
             num_files (int, optional): The number of files to read. If not specified, all files will be read.
                 Default is None.
             download_files (bool, optional): Whether to automatically cache remote files locally during operations.
@@ -46,6 +48,7 @@ class S3Reader(BaseReader):
         self.__prefix = prefix
         self.__region_name = region_name
         self.__profile_name = profile_name
+        self.__client_options = client_options
 
     def _create_backend(self) -> S3Backend:
         """Create a new S3Backend instance.
@@ -53,7 +56,7 @@ class S3Reader(BaseReader):
         This method is called to create or recreate the backend when needed or after unpickling.
         """
         session = boto3.Session(region_name=self.__region_name, profile_name=self.__profile_name)
-        return S3Backend(self.__bucket, self.__prefix, session)
+        return S3Backend(self.__bucket, self.__prefix, session, self.__client_options)
 
     def _get_reader_params(self) -> str:
         """Get a string representation of the reader parameters used to create the backend."""

--- a/src/pythermondt/writers/azure_writer.py
+++ b/src/pythermondt/writers/azure_writer.py
@@ -2,7 +2,7 @@ from azure.core.credentials import TokenCredential
 
 from ..data import DataContainer
 from ..data.datacontainer.serialization_ops import CompressionType
-from ..io import AzureBlobBackend, IOPathWrapper
+from ..io import AzureBlobBackend, AzureBlobClientOptions, IOPathWrapper
 from .base_writer import BaseWriter
 
 
@@ -14,6 +14,7 @@ class AzureBlobWriter(BaseWriter):
         prefix: str,
         connection_string: str | None = None,
         credential: TokenCredential | None = None,
+        client_options: AzureBlobClientOptions | None = None,
     ):
         """Initialize writer for Azure Blob Storage.
 
@@ -26,6 +27,7 @@ class AzureBlobWriter(BaseWriter):
             prefix (str): Prefix (folder path) within container
             connection_string (str | None): Optional connection string (overrides default auth)
             credential (TokenCredential | None): Optional Azure TokenCredential (overrides default auth)
+            client_options (AzureBlobClientOptions | None): Optional Azure client tuning options.
         """
         super().__init__()
         self.__account_url = account_url
@@ -33,6 +35,7 @@ class AzureBlobWriter(BaseWriter):
         self.__prefix = prefix
         self.__connection_string = connection_string
         self.__credential = credential
+        self.__client_options = client_options
 
     def _create_backend(self) -> AzureBlobBackend:
         """Create a new AzureBlobBackend instance."""
@@ -43,6 +46,7 @@ class AzureBlobWriter(BaseWriter):
             prefix=self.__prefix,
             connection_string=self.__connection_string,
             credential=self.__credential,
+            client_options=self.__client_options,
         )
         # pylint: enable=duplicate-code
 

--- a/src/pythermondt/writers/azure_writer.py
+++ b/src/pythermondt/writers/azure_writer.py
@@ -7,6 +7,7 @@ from .base_writer import BaseWriter
 
 
 class AzureBlobWriter(BaseWriter):
+    # pylint: disable=duplicate-code
     def __init__(
         self,
         account_url: str,
@@ -39,7 +40,6 @@ class AzureBlobWriter(BaseWriter):
 
     def _create_backend(self) -> AzureBlobBackend:
         """Create a new AzureBlobBackend instance."""
-        # pylint: disable=duplicate-code
         return AzureBlobBackend(
             account_url=self.__account_url,
             container_name=self.__container_name,
@@ -48,7 +48,6 @@ class AzureBlobWriter(BaseWriter):
             credential=self.__credential,
             client_options=self.__client_options,
         )
-        # pylint: enable=duplicate-code
 
     def write(
         self,

--- a/src/pythermondt/writers/s3_writer.py
+++ b/src/pythermondt/writers/s3_writer.py
@@ -7,6 +7,7 @@ from .base_writer import BaseWriter
 
 
 class S3Writer(BaseWriter):
+    # pylint: disable=duplicate-code
     def __init__(
         self,
         bucket: str,
@@ -35,10 +36,8 @@ class S3Writer(BaseWriter):
         self.__client_options = client_options
 
     def _create_backend(self) -> S3Backend:
-        # pylint: disable=duplicate-code
         session = boto3.Session(region_name=self.__region_name, profile_name=self.__profile_name)
         return S3Backend(self.__bucket, self.__prefix, session, self.__client_options)
-        # pylint: enable=duplicate-code
 
     def write(
         self,

--- a/src/pythermondt/writers/s3_writer.py
+++ b/src/pythermondt/writers/s3_writer.py
@@ -2,12 +2,19 @@ import boto3
 
 from ..data import DataContainer
 from ..data.datacontainer.serialization_ops import CompressionType
-from ..io import IOPathWrapper, S3Backend
+from ..io import IOPathWrapper, S3Backend, S3ClientOptions
 from .base_writer import BaseWriter
 
 
 class S3Writer(BaseWriter):
-    def __init__(self, bucket: str, prefix: str, region_name: str | None = None, profile_name: str | None = None):
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str,
+        region_name: str | None = None,
+        profile_name: str | None = None,
+        client_options: S3ClientOptions | None = None,
+    ):
         """Instantiates a new instance of the S3Writer class.
 
         Args:
@@ -16,6 +23,7 @@ class S3Writer(BaseWriter):
             region_name (str | None, optional): The AWS region to use. Defaults to None.
             profile_name (str | None, optional): The AWS profile to use. Defaults to None.
                 Default is a new boto3 session with the default profile.
+            client_options (S3ClientOptions | None): Optional S3 client tuning options.
         """
         super().__init__()
 
@@ -24,11 +32,12 @@ class S3Writer(BaseWriter):
         self.__prefix = prefix
         self.__region_name = region_name
         self.__profile_name = profile_name
+        self.__client_options = client_options
 
     def _create_backend(self) -> S3Backend:
         # pylint: disable=duplicate-code
         session = boto3.Session(region_name=self.__region_name, profile_name=self.__profile_name)
-        return S3Backend(self.__bucket, self.__prefix, session)
+        return S3Backend(self.__bucket, self.__prefix, session, self.__client_options)
         # pylint: enable=duplicate-code
 
     def write(

--- a/src/pythermondt/writers/s3_writer.py
+++ b/src/pythermondt/writers/s3_writer.py
@@ -28,7 +28,7 @@ class S3Writer(BaseWriter):
         """
         super().__init__()
 
-        # Use default boto3 session if none is provided
+        # Maintain state for what is needed to create the backend
         self.__bucket = bucket
         self.__prefix = prefix
         self.__region_name = region_name

--- a/tests/io/backends/test_azure_backend.py
+++ b/tests/io/backends/test_azure_backend.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from azure.core.exceptions import AzureError
 
-from pythermondt.io import AzureBlobBackend, IOPathWrapper
+from pythermondt.io import AzureBlobBackend, AzureBlobClientOptions, IOPathWrapper
 
 
 @pytest.fixture
@@ -56,6 +56,59 @@ def test_init_with_default_credential():
 
         mock_default_cred.assert_called_once()
         mock_client_class.assert_called_once_with("https://test.blob.core.windows.net", credential=mock_cred_instance)
+        backend.close()
+
+
+def test_init_with_client_options_uses_blob_service_client_kwargs():
+    """Test client options are forwarded when using explicit credentials."""
+    client_options = AzureBlobClientOptions(
+        max_single_put_size=0,
+        max_block_size=8 * 1024 * 1024,
+        connection_timeout=600,
+        read_timeout=600,
+    )
+
+    with patch("pythermondt.io.backends.azure_backend.BlobServiceClient") as mock_client_class:
+        mock_client_class.return_value = MagicMock()
+        credential = MagicMock()
+
+        backend = AzureBlobBackend(
+            account_url="https://test.blob.core.windows.net",
+            container_name="test-container",
+            credential=credential,
+            client_options=client_options,
+        )
+
+        mock_client_class.assert_called_once_with(
+            "https://test.blob.core.windows.net",
+            credential=credential,
+            max_single_put_size=0,
+            max_block_size=8 * 1024 * 1024,
+            connection_timeout=600,
+            read_timeout=600,
+        )
+        backend.close()
+
+
+def test_init_with_connection_string_forwards_client_options():
+    """Test client options are forwarded for connection-string auth too."""
+    client_options = AzureBlobClientOptions(max_single_put_size=0, read_timeout=600)
+
+    with patch("pythermondt.io.backends.azure_backend.BlobServiceClient") as mock_client_class:
+        mock_client_class.from_connection_string.return_value = MagicMock()
+
+        backend = AzureBlobBackend(
+            account_url="https://test.blob.core.windows.net",
+            container_name="test-container",
+            connection_string="DefaultEndpointsProtocol=https;AccountName=test;AccountKey=fake==;EndpointSuffix=core.windows.net",
+            client_options=client_options,
+        )
+
+        mock_client_class.from_connection_string.assert_called_once_with(
+            "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=fake==;EndpointSuffix=core.windows.net",
+            max_single_put_size=0,
+            read_timeout=600,
+        )
         backend.close()
 
 

--- a/tests/io/backends/test_s3_backend.py
+++ b/tests/io/backends/test_s3_backend.py
@@ -1,12 +1,13 @@
 """S3-specific backend tests."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
-from pythermondt.io import IOPathWrapper, S3Backend
+from pythermondt.io import IOPathWrapper, S3Backend, S3ClientOptions
 
 
 @pytest.fixture
@@ -72,6 +73,24 @@ def test_write_file_upload_error(s3_backend):
             s3_backend.write_file(data, "test/new_file.txt")
 
         assert "Failed to upload file to S3" in str(exc.value)
+
+
+def test_init_with_client_options_builds_botocore_config():
+    """Test S3 client options are converted into botocore config."""
+    session = MagicMock()
+    session.client.return_value = MagicMock()
+    client_options = S3ClientOptions(connect_timeout=10, read_timeout=20, max_pool_connections=30)
+
+    backend = S3Backend(bucket="test-bucket", prefix="test/", session=session, client_options=client_options)
+
+    session.client.assert_called_once()
+    assert session.client.call_args.args == ("s3",)
+    config = session.client.call_args.kwargs["config"]
+    assert isinstance(config, Config)
+    assert config.connect_timeout == 10  # type: ignore
+    assert config.read_timeout == 20  # type: ignore
+    assert config.max_pool_connections == 30  # type: ignore
+    backend.close()
 
 
 def test_exists_unexpected_error(s3_backend):


### PR DESCRIPTION
- Added AzureBlobClientOptions and S3ClientOptions dataclasses for configuring backend-specific client behavior
- Made BackendClientOptions a shared zero-field dataclass base with as_kwargs() helper for clean SDK configuration forwarding
- Updated AzureBlobBackend to accept and forward client_options to BlobServiceClient construction (both direct and connection_string paths)
- Updated S3Backend to accept and forward client_options as botocore.config.Config to session.client()
- Propagated client_options through AzureBlobReader/Writter and S3Reader/Writter to maintain configuration through the reader/writer wrappers
- Exported the new option types in pythermondt.io and pythermondt.io.backends for public access
- Added backend tests verifying option forwarding for both auth paths in Azure and config creation in S3

Enables per-backend instance tuning of Azure Blob Storage transfer behavior (max_single_put_size, max_block_size, timeouts) and S3 client settings (timeouts, pool connections) without modifying library-wide defaults or using loose kwargs.