### PR TITLE
Fix num_workers validation to handle string input from env vars

### DIFF
--- a/src/pythermondt/config.py
+++ b/src/pythermondt/config.py
@@ -67,7 +67,7 @@ class Settings(BaseSettings):
 
         return absolute
 
-    @field_validator("num_workers", mode="before")
+    @field_validator("num_workers", mode="after")
     @classmethod
     def validate_num_workers(cls, v: int) -> int:
         if v < 1:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,17 +12,18 @@ def test_num_workers_zero_raises():
         Settings(num_workers=0)
 
 
-@pytest.mark.parametrize("num_workers", [-5, -1])
+@pytest.mark.parametrize("num_workers", [-5, -1, "-5", "-1"])
 def test_num_workers_negative_raises(num_workers):
     """Test that negative num_workers raises ValidationError."""
     with pytest.raises(ValidationError, match="num_workers must be at least 1"):
         Settings(num_workers=num_workers)
 
 
-def test_num_workers_valid():
-    """Test that a valid num_workers is accepted."""
-    s = Settings(num_workers=2)
-    assert s.num_workers == 2
+@pytest.mark.parametrize("num_workers", [1, 2, "1", "2"])
+def test_num_workers_valid(num_workers):
+    """Test that valid num_workers values are accepted."""
+    s = Settings(num_workers=num_workers)
+    assert s.num_workers == int(num_workers)
 
 
 def test_invalid_log_level_raises():


### PR DESCRIPTION
- Change field validator mode from "before" to "after" in config.py so pydantic coerces string input to int before the range check runs
- Parameterize test_num_workers_negative_raises and test_num_workers_valid with both int and string inputs to cover env var path

Closes #387