### PR TITLE
Remove objsize dependency and replace with in-repo deep-size traversal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "ipywidgets>=8.0",
     "ipykernel>=6.25",
     "pydantic-settings>=2.6",
-    "objsize>=0.7",
 
     # Data loading and visualization
     "h5py>=3.9",

--- a/src/pythermondt/data/datacontainer/node.py
+++ b/src/pythermondt/data/datacontainer/node.py
@@ -1,11 +1,10 @@
+import gc
+import types
 from abc import ABC, abstractmethod
 from collections.abc import ItemsView, Iterator
 from enum import Enum
-import gc
 from sys import getsizeof
-import types
 
-import objsize
 import torch
 from torch import Tensor
 
@@ -146,7 +145,7 @@ class AttributeNode(BaseNode, ABC):
 
     def memory_bytes(self) -> int:
         """Returns the memory size of the node in bytes."""
-        return super().memory_bytes() + objsize.get_deep_size(self.__attributes)
+        return super().memory_bytes() + _deep_size(self.__attributes)
 
 
 class GroupNode(AttributeNode):

--- a/src/pythermondt/data/datacontainer/node.py
+++ b/src/pythermondt/data/datacontainer/node.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod
-from collections.abc import ItemsView
+from collections.abc import ItemsView, Iterator
 from enum import Enum
+import gc
 from sys import getsizeof
+import types
 
 import objsize
 import torch
@@ -10,6 +12,49 @@ from torch import Tensor
 from ..units import Unit
 
 AttributeTypes = str | int | float | list | tuple | dict | Unit
+
+_SHARED_ATTRIBUTE_OBJECT_TYPES = (
+    type,
+    types.ModuleType,
+    types.FrameType,
+    types.BuiltinFunctionType,
+    types.FunctionType,
+    types.LambdaType,
+)
+
+
+def _iter_referents(*objs: object) -> Iterator[object]:
+    """Yield referents for deep-size traversal."""
+    yield from gc.get_referents(*objs)
+
+    # `gc.get_referents()` does not consistently expose `__dict__` across Python versions.
+    for obj in objs:
+        try:
+            yield vars(obj)
+        except (TypeError, AttributeError):
+            pass
+
+
+def _deep_size(*objs: object) -> int:
+    """Calculate deep size without double-counting shared objects."""
+    seen = {id(None)}
+    total = 0
+    queue = list(objs)
+
+    while queue:
+        current: list[object] = []
+        for obj in queue:
+            obj_id = id(obj)
+            if obj_id in seen or isinstance(obj, _SHARED_ATTRIBUTE_OBJECT_TYPES):
+                continue
+
+            seen.add(obj_id)
+            current.append(obj)
+            total += getsizeof(obj)
+
+        queue = list(_iter_referents(*current)) if current else []
+
+    return total
 
 
 class NodeType(Enum):

--- a/tests/data/datacontainer/test_node.py
+++ b/tests/data/datacontainer/test_node.py
@@ -1,7 +1,10 @@
+from sys import getsizeof
+
 import pytest
 import torch
 from torch import Tensor
 
+from pythermondt.data import units
 from pythermondt.data.datacontainer.node import DataNode, GroupNode, NodeType, RootNode
 
 
@@ -133,6 +136,83 @@ def test_group_node_memory_with_attributes(group_node: GroupNode):
     assert memory_with_attr > memory_empty
 
 
+@pytest.mark.parametrize(
+    ("attributes", "expected_attribute_bytes"),
+    [
+        ({}, getsizeof({})),
+        (
+            {"test_attr": "test_value"},
+            getsizeof({"test_attr": "test_value"}) + getsizeof("test_value"),
+        ),
+        (
+            {"shape": [5, 6]},
+            getsizeof({"shape": [5, 6]}) + getsizeof([5, 6]) + getsizeof(5) + getsizeof(6),
+        ),
+        (
+            {"Unit": units.kelvin},
+            getsizeof({"Unit": units.kelvin})
+            + getsizeof(units.kelvin)
+            + getsizeof(units.kelvin.__dict__)
+            + sum(getsizeof(value) for value in vars(units.kelvin).values()),
+        ),
+        (
+            {
+                "Source": "Simulation",
+                "NoiseLevel": 0.1,
+                "LabelIds": [1, 2, 3],
+                "Unit": units.arbitrary,
+            },
+            getsizeof(
+                {
+                    "Source": "Simulation",
+                    "NoiseLevel": 0.1,
+                    "LabelIds": [1, 2, 3],
+                    "Unit": units.arbitrary,
+                }
+            )
+            + getsizeof("Simulation")
+            + getsizeof(0.1)
+            + getsizeof([1, 2, 3])
+            + getsizeof(1)
+            + getsizeof(2)
+            + getsizeof(3)
+            + getsizeof(units.arbitrary)
+            + getsizeof(units.arbitrary.__dict__)
+            + getsizeof("arbitrary")
+            + getsizeof("a. u."),
+        ),
+    ],
+)
+def test_group_node_memory_bytes_matches_expected_values(attributes: dict[str, object], expected_attribute_bytes: int):
+    """Test GroupNode memory using explicit `sys.getsizeof` formulas.
+
+    This follows objsize's own testing strategy: compute the expectation from the
+    known object graph instead of copying the deep-size traversal into the test.
+    """
+    group_node = GroupNode("parity_group")
+    group_node.add_attributes(**attributes)  # type: ignore
+
+    expected_memory_bytes = getsizeof(group_node) + getsizeof(group_node.name) + getsizeof(group_node.type)
+    assert group_node.memory_bytes() == expected_memory_bytes + expected_attribute_bytes
+
+
+def test_group_node_memory_bytes_matches_expected_values_with_shared_references():
+    """Test GroupNode memory counts shared attribute objects only once."""
+    shared_list = ["hot", "cold"]
+    group_node = GroupNode("shared_group")
+    group_node.add_attributes(a=shared_list, b=shared_list, meta={"labels": shared_list})
+
+    expected_attribute_bytes = (
+        getsizeof({"a": shared_list, "b": shared_list, "meta": {"labels": shared_list}})
+        + getsizeof(shared_list)
+        + getsizeof("hot")
+        + getsizeof("cold")
+        + getsizeof({"labels": shared_list})
+    )
+    expected_memory_bytes = getsizeof(group_node) + getsizeof(group_node.name) + getsizeof(group_node.type)
+    assert group_node.memory_bytes() == expected_memory_bytes + expected_attribute_bytes
+
+
 def test_data_node_memory_bytes(data_node: DataNode):
     """Test memory calculation for DataNode."""
     memory = data_node.memory_bytes()
@@ -160,6 +240,47 @@ def test_data_node_empty_tensor_memory():
     memory = empty_node.memory_bytes()
     assert isinstance(memory, int)
     assert memory > 0
+
+
+def test_data_node_memory_bytes_matches_expected_values_for_attributes(sample_tensor: Tensor):
+    """Test DataNode memory using explicit `sys.getsizeof` formulas."""
+    data_node = DataNode("parity_data", sample_tensor)
+    data_node.add_attributes(
+        Source="Simulation",
+        LabelIds=[1, 2, 3],
+        Shapes={"Circle": 2, "Line": 1},
+        Unit=units.kelvin,
+    )
+
+    expected_attribute_bytes = (
+        getsizeof(
+            {
+                "Source": "Simulation",
+                "LabelIds": [1, 2, 3],
+                "Shapes": {"Circle": 2, "Line": 1},
+                "Unit": units.kelvin,
+            }
+        )
+        + getsizeof("Simulation")
+        + getsizeof([1, 2, 3])
+        + getsizeof(1)
+        + getsizeof(2)
+        + getsizeof(3)
+        + getsizeof({"Circle": 2, "Line": 1})
+        + getsizeof(units.kelvin)
+        + getsizeof(units.kelvin.__dict__)
+        + sum(getsizeof(value) for value in vars(units.kelvin).values())
+    )
+    expected_memory_bytes = (
+        getsizeof(data_node)
+        + getsizeof(data_node.name)
+        + getsizeof(data_node.type)
+        + expected_attribute_bytes
+        + getsizeof(data_node.data)
+        + data_node.data.element_size() * data_node.data.numel()
+    )
+
+    assert data_node.memory_bytes() == expected_memory_bytes
 
 
 # Node Type Enum tests


### PR DESCRIPTION
- Remove `objsize>=0.7` from project dependencies in pyproject.toml
- Add local `_deep_size()` and `_iter_referents()` helpers in node.py for attribute deep-size calculation
- Add explicit `sys.getsizeof`-based parity tests in test_node.py covering empty, simple, nested, Unit, and shared-reference cases

Replaces the external dependency with a minimal local implementation that keeps the exact memory sizing behavior while reducing supply chain attack surface.