### PR TITLE
Add set operations to add or update datasets and attributes

### DIFF
--- a/src/pythermondt/data/datacontainer/attribute_ops.py
+++ b/src/pythermondt/data/datacontainer/attribute_ops.py
@@ -152,6 +152,35 @@ class AttributeOps(BaseOps):
         """
         self.nodes(path, DataNode, GroupNode).update_attributes(**attributes)  # type: ignore[union-attr]
 
+    def set_attribute(self, path: str, key: str, value: str | int | float | list | tuple | dict | Unit):
+        """Set an attribute in a specified group or dataset (upsert).
+
+        Adds the attribute if it does not exist, updates it if it does.
+
+        Args:
+            path (str): The path to the group or dataset.
+            key (str): The key of the attribute.
+            value (str | int | float | list | tuple | dict | Unit): The value of the attribute.
+
+        Raises:
+            KeyError: If the group or dataset does not exist.
+        """
+        self.nodes(path, DataNode, GroupNode).set_attribute(key, value)  # type: ignore[union-attr]
+
+    def set_attributes(self, path: str, **attributes: str | int | float | list | tuple | dict | Unit):
+        """Set multiple attributes in a specified group or dataset (upsert).
+
+        Adds attributes if they do not exist, updates them if they do.
+
+        Args:
+            path (str): The path to the group or dataset.
+            **attributes (Dict[str, str | int | float | list | tuple | dict | Unit]): The attributes to set.
+
+        Raises:
+            KeyError: If the group or dataset does not exist.
+        """
+        self.nodes(path, DataNode, GroupNode).set_attributes(**attributes)  # type: ignore[union-attr]
+
     def update_unit(self, path: str, unit: Unit):
         """Update the unit information of the specified dataset.
 

--- a/src/pythermondt/data/datacontainer/attribute_ops.py
+++ b/src/pythermondt/data/datacontainer/attribute_ops.py
@@ -152,7 +152,14 @@ class AttributeOps(BaseOps):
         """
         self.nodes(path, DataNode, GroupNode).update_attributes(**attributes)  # type: ignore[union-attr]
 
-    def set_attribute(self, path: str, key: str, value: str | int | float | list | tuple | dict | Unit):
+    def set_attribute(
+        self,
+        path: str,
+        key: str,
+        value: str | int | float | list | tuple | dict | Unit,
+        *,
+        check_type: bool = True,
+    ):
         """Set an attribute in a specified group or dataset (upsert).
 
         Adds the attribute if it does not exist, updates it if it does.
@@ -161,25 +168,40 @@ class AttributeOps(BaseOps):
             path (str): The path to the group or dataset.
             key (str): The key of the attribute.
             value (str | int | float | list | tuple | dict | Unit): The value of the attribute.
+            check_type (bool): If True (default), enforce type consistency for existing
+                attributes. If False, allow type changes on existing attributes.
 
         Raises:
             KeyError: If the group or dataset does not exist.
+            TypeError: If check_type is True and the value type does not match the
+                existing attribute.
         """
-        self.nodes(path, DataNode, GroupNode).set_attribute(key, value)  # type: ignore[union-attr]
+        self.nodes(path, DataNode, GroupNode).set_attribute(key, value, check_type=check_type)  # type: ignore[union-attr]
 
-    def set_attributes(self, path: str, **attributes: str | int | float | list | tuple | dict | Unit):
+    def set_attributes(
+        self,
+        path: str,
+        *,
+        check_type: bool = True,
+        **attributes: str | int | float | list | tuple | dict | Unit,
+    ):
         """Set multiple attributes in a specified group or dataset (upsert).
 
         Adds attributes if they do not exist, updates them if they do.
 
         Args:
             path (str): The path to the group or dataset.
-            **attributes (Dict[str, str | int | float | list | tuple | dict | Unit]): The attributes to set.
+            check_type (bool): If True (default), enforce type consistency for existing
+                attributes. If False, allow type changes on existing attributes.
+            **attributes (Dict[str, str | int | float | list | tuple | dict | Unit]):
+                The attributes to set.
 
         Raises:
             KeyError: If the group or dataset does not exist.
+            TypeError: If check_type is True and a value type does not match an
+                existing attribute.
         """
-        self.nodes(path, DataNode, GroupNode).set_attributes(**attributes)  # type: ignore[union-attr]
+        self.nodes(path, DataNode, GroupNode).set_attributes(check_type=check_type, **attributes)  # type: ignore[union-attr]
 
     def update_unit(self, path: str, unit: Unit):
         """Update the unit information of the specified dataset.

--- a/src/pythermondt/data/datacontainer/base.py
+++ b/src/pythermondt/data/datacontainer/base.py
@@ -103,6 +103,9 @@ class NodeAccessor:
     def __setitem__(self, key: str, value: NodeTypes):
         self.__set_node(key, value)
 
+    def __contains__(self, key: str) -> bool:
+        return key in self.__nodes
+
     # Overriding the call method to access nodes ==> Makes the node property callable like a function
     @overload
     def __call__(self, key: str) -> NodeTypes: ...

--- a/src/pythermondt/data/datacontainer/dataset_ops.py
+++ b/src/pythermondt/data/datacontainer/dataset_ops.py
@@ -159,10 +159,7 @@ class DatasetOps(BaseOps):
                 data = torch.empty(0)
             self.nodes(key, DataNode).data = data
         else:
-            if data is None:
-                self.nodes[key] = DataNode(name)
-            else:
-                self.nodes[key] = DataNode(name, data)
+            self.nodes[key] = DataNode(name, data)
 
     def set_datasets(self, path: str, **datasets: Tensor | ndarray | None):
         """Set multiple datasets at a specified path (upsert).

--- a/src/pythermondt/data/datacontainer/dataset_ops.py
+++ b/src/pythermondt/data/datacontainer/dataset_ops.py
@@ -135,3 +135,47 @@ class DatasetOps(BaseOps):
         """
         for path, data in updates:
             self.update_dataset(path, data)
+
+    def set_dataset(self, path: str, name: str, data: Tensor | ndarray | None = None):
+        """Set a dataset at a specified path (upsert).
+
+        Adds the dataset if it does not exist, updates it if it does.
+
+        Args:
+            path (str): The path to the parent group.
+            name (str): The name of the dataset.
+            data (Tensor | ndarray, optional): The data to store. If None, an empty dataset is created.
+
+        Raises:
+            KeyError: If the parent group does not exist.
+        """
+        key, _, _ = generate_key(path, name)
+
+        if isinstance(data, ndarray):
+            data = torch.from_numpy(data)
+
+        if key in self.nodes:
+            if data is None:
+                data = torch.empty(0)
+            self.nodes(key, DataNode).data = data
+        else:
+            if data is None:
+                self.nodes[key] = DataNode(name)
+            else:
+                self.nodes[key] = DataNode(name, data)
+
+    def set_datasets(self, path: str, **datasets: Tensor | ndarray | None):
+        """Set multiple datasets at a specified path (upsert).
+
+        Adds datasets if they do not exist, updates them if they do.
+
+        Args:
+            path (str): The path to the parent group.
+            **datasets (Dict[str, Optional[Tensor | ndarray]]): The datasets to set.
+                The specified key will become the name of the dataset.
+
+        Raises:
+            KeyError: If the parent group does not exist.
+        """
+        for name, data in datasets.items():
+            self.set_dataset(path, name, data)

--- a/src/pythermondt/data/datacontainer/node.py
+++ b/src/pythermondt/data/datacontainer/node.py
@@ -140,6 +140,15 @@ class AttributeNode(BaseNode, ABC):
         for update_key, update_value in attributes.items():
             self.update_attribute(update_key, update_value)
 
+    def set_attribute(self, key: str, value: AttributeTypes) -> None:
+        """Set an attribute (add if missing, update if present)."""
+        self.__attributes[key] = value
+
+    def set_attributes(self, **attributes: AttributeTypes) -> None:
+        """Set multiple attributes (add if missing, update if present)."""
+        for key, value in attributes.items():
+            self.__attributes[key] = value
+
     def clear_attributes(self) -> None:
         self.__attributes.clear()
 

--- a/src/pythermondt/data/datacontainer/node.py
+++ b/src/pythermondt/data/datacontainer/node.py
@@ -140,14 +140,33 @@ class AttributeNode(BaseNode, ABC):
         for update_key, update_value in attributes.items():
             self.update_attribute(update_key, update_value)
 
-    def set_attribute(self, key: str, value: AttributeTypes) -> None:
-        """Set an attribute (add if missing, update if present)."""
-        self.__attributes[key] = value
+    def set_attribute(self, key: str, value: AttributeTypes, *, check_type: bool = True) -> None:
+        """Set an attribute (add if missing, update if present).
 
-    def set_attributes(self, **attributes: AttributeTypes) -> None:
-        """Set multiple attributes (add if missing, update if present)."""
+        Args:
+            key (str): The attribute key.
+            value (AttributeTypes): The attribute value.
+            check_type (bool): If True (default), use update_attribute for existing keys to enforce type consistency.
+                If False, allow type changes on existing attributes via direct assignment.
+        """
+        if key in self.__attributes:
+            if check_type:
+                self.update_attribute(key, value)
+            else:
+                self.__attributes[key] = value
+        else:
+            self.add_attribute(key, value)
+
+    def set_attributes(self, *, check_type: bool = True, **attributes: AttributeTypes) -> None:
+        """Set multiple attributes (add if missing, update if present).
+
+        Args:
+            check_type (bool): If True (default), use update_attribute for existing keys to enforce type consistency.
+                If False, allow type changes on existing attributes via direct assignment.
+            **attributes (AttributeTypes): The attributes to set.
+        """
         for key, value in attributes.items():
-            self.__attributes[key] = value
+            self.set_attribute(key, value, check_type=check_type)
 
     def clear_attributes(self) -> None:
         self.__attributes.clear()

--- a/tests/data/datacontainer/test_attribute_ops.py
+++ b/tests/data/datacontainer/test_attribute_ops.py
@@ -201,8 +201,3 @@ def test_missing_unit(attr_container: DataContainer):
     """Test getting a unit from a dataset that does not have unit information returns undefined."""
     unit = attr_container.get_unit("/testdata")
     assert unit == units.undefined
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_base.py
+++ b/tests/data/datacontainer/test_base.py
@@ -207,8 +207,3 @@ def test_data_container_base_cannot_be_instantiated():
         TypeError, match=escape("DataContainerBase is a base class and cannot be instantiated directly.")
     ):
         DataContainerBase()
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_data_container.py
+++ b/tests/data/datacontainer/test_data_container.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 
+import numpy as np
 import pytest
 import torch
 from torch import Tensor
@@ -120,6 +121,159 @@ def test_error_handling(empty_container: DataContainer):
     with pytest.raises(KeyError):
         empty_container.add_group("/", "TestGroup")
         empty_container.add_group("/", "TestGroup")
+
+
+def test_set_attribute_new(empty_container: DataContainer):
+    """Test set_attribute adds attribute when it does not exist."""
+    empty_container.add_group("/", "TestGroup")
+
+    # Attribute does not exist yet - should add it
+    empty_container.set_attribute("/TestGroup", "new_attr", "value1")
+    assert empty_container.get_attribute("/TestGroup", "new_attr") == "value1"
+
+
+def test_set_attribute_existing(empty_container: DataContainer):
+    """Test set_attribute updates attribute when it already exists."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attribute("/TestGroup", "existing_attr", "original")
+
+    # Attribute exists - should update it
+    empty_container.set_attribute("/TestGroup", "existing_attr", "updated")
+    assert empty_container.get_attribute("/TestGroup", "existing_attr") == "updated"
+
+
+def test_set_attribute_multiple_times(empty_container: DataContainer):
+    """Test set_attribute can be called multiple times without try/except."""
+    empty_container.add_group("/", "TestGroup")
+
+    # Multiple calls should work without errors
+    empty_container.set_attribute("/TestGroup", "attr", "value1")
+    assert empty_container.get_attribute("/TestGroup", "attr") == "value1"
+
+    empty_container.set_attribute("/TestGroup", "attr", "value2")
+    assert empty_container.get_attribute("/TestGroup", "attr") == "value2"
+
+    empty_container.set_attribute("/TestGroup", "attr", "value3")
+    assert empty_container.get_attribute("/TestGroup", "attr") == "value3"
+
+
+def test_set_attributes_new(empty_container: DataContainer):
+    """Test set_attributes adds multiple attributes when they do not exist."""
+    empty_container.add_group("/", "TestGroup")
+
+    empty_container.set_attributes("/TestGroup", attr1="value1", attr2=42, attr3=3.14)
+    assert empty_container.get_attribute("/TestGroup", "attr1") == "value1"
+    assert empty_container.get_attribute("/TestGroup", "attr2") == 42
+    assert empty_container.get_attribute("/TestGroup", "attr3") == 3.14
+
+
+def test_set_attributes_existing(empty_container: DataContainer):
+    """Test set_attributes updates multiple attributes when they already exist."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attributes("/TestGroup", attr1="original1", attr2="original2")
+
+    empty_container.set_attributes("/TestGroup", attr1="updated1", attr2="updated2")
+    assert empty_container.get_attribute("/TestGroup", "attr1") == "updated1"
+    assert empty_container.get_attribute("/TestGroup", "attr2") == "updated2"
+
+
+def test_set_attributes_mixed(empty_container: DataContainer):
+    """Test set_attributes with mix of existing and new attributes."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attribute("/TestGroup", "existing", "original")
+
+    # Mix of existing and new attributes
+    empty_container.set_attributes("/TestGroup", existing="updated", new_attr="brand_new")
+    assert empty_container.get_attribute("/TestGroup", "existing") == "updated"
+    assert empty_container.get_attribute("/TestGroup", "new_attr") == "brand_new"
+
+
+def test_set_dataset_new(empty_container: DataContainer, sample_tensor: Tensor):
+    """Test set_dataset adds dataset when it does not exist."""
+    # Dataset does not exist yet - should add it
+    empty_container.set_dataset("/", "NewData", sample_tensor)
+    assert "NewData" in empty_container.get_all_dataset_names()
+    assert torch.equal(empty_container.get_dataset("/NewData"), sample_tensor)
+
+
+def test_set_dataset_existing(empty_container: DataContainer, sample_tensor: Tensor, sample_eye_tensor: Tensor):
+    """Test set_dataset updates dataset when it already exists."""
+    empty_container.add_dataset("/", "ExistingData", sample_tensor)
+
+    # Dataset exists - should update it
+    empty_container.set_dataset("/", "ExistingData", sample_eye_tensor)
+    assert torch.equal(empty_container.get_dataset("/ExistingData"), sample_eye_tensor)
+
+
+def test_set_dataset_multiple_times(empty_container: DataContainer, sample_tensor: Tensor, sample_eye_tensor: Tensor):
+    """Test set_dataset can be called multiple times without try/except."""
+    # Multiple calls should work without errors
+    empty_container.set_dataset("/", "Data", sample_tensor)
+    assert torch.equal(empty_container.get_dataset("/Data"), sample_tensor)
+
+    empty_container.set_dataset("/", "Data", sample_eye_tensor)
+    assert torch.equal(empty_container.get_dataset("/Data"), sample_eye_tensor)
+
+
+def test_set_dataset_with_ndarray(empty_container: DataContainer, sample_ndarray: np.ndarray, sample_tensor: Tensor):
+    """Test set_dataset accepts numpy arrays (converts to tensor)."""
+    # Should accept ndarray and convert to tensor
+    empty_container.set_dataset("/", "NdarrayData", sample_ndarray)
+    result = empty_container.get_dataset("/NdarrayData")
+    assert torch.equal(result, sample_tensor)
+
+
+def test_set_datasets_new(empty_container: DataContainer, sample_tensor: Tensor, sample_eye_tensor: Tensor):
+    """Test set_datasets adds multiple datasets when they do not exist."""
+    empty_container.set_datasets("/", Data1=sample_tensor, Data2=sample_eye_tensor)
+    assert "Data1" in empty_container.get_all_dataset_names()
+    assert "Data2" in empty_container.get_all_dataset_names()
+    assert torch.equal(empty_container.get_dataset("/Data1"), sample_tensor)
+    assert torch.equal(empty_container.get_dataset("/Data2"), sample_eye_tensor)
+
+
+def test_set_datasets_existing(empty_container: DataContainer, sample_tensor: Tensor, sample_eye_tensor: Tensor):
+    """Test set_datasets updates multiple datasets when they already exist."""
+    empty_container.add_datasets("/", Data1=sample_tensor, Data2=sample_eye_tensor)
+
+    # Update both datasets
+    empty_container.set_datasets("/", Data1=sample_eye_tensor, Data2=sample_tensor)
+    assert torch.equal(empty_container.get_dataset("/Data1"), sample_eye_tensor)
+    assert torch.equal(empty_container.get_dataset("/Data2"), sample_tensor)
+
+
+def test_set_datasets_mixed(empty_container: DataContainer, sample_tensor: Tensor, sample_eye_tensor: Tensor):
+    """Test set_datasets with mix of existing and new datasets."""
+    empty_container.add_dataset("/", "ExistingData", sample_tensor)
+
+    # Mix of existing and new datasets
+    empty_container.set_datasets("/", ExistingData=sample_eye_tensor, NewData=sample_tensor)
+    assert torch.equal(empty_container.get_dataset("/ExistingData"), sample_eye_tensor)
+    assert torch.equal(empty_container.get_dataset("/NewData"), sample_tensor)
+
+
+def test_set_attribute_parent_group_not_exist(empty_container: DataContainer):
+    """Test set_attribute raises KeyError when parent group does not exist."""
+    with pytest.raises(KeyError):
+        empty_container.set_attribute("/NonExistentGroup", "attr", "value")
+
+
+def test_set_attributes_parent_group_not_exist(empty_container: DataContainer):
+    """Test set_attributes raises KeyError when parent group does not exist."""
+    with pytest.raises(KeyError):
+        empty_container.set_attributes("/NonExistentGroup", attr1="value1", attr2="value2")
+
+
+def test_set_dataset_parent_group_not_exist(empty_container: DataContainer, sample_tensor: Tensor):
+    """Test set_dataset raises KeyError when parent group does not exist."""
+    with pytest.raises(KeyError):
+        empty_container.set_dataset("/NonExistentGroup", "Data", sample_tensor)
+
+
+def test_set_datasets_parent_group_not_exist(empty_container: DataContainer, sample_tensor: Tensor):
+    """Test set_datasets raises KeyError when parent group does not exist."""
+    with pytest.raises(KeyError):
+        empty_container.set_datasets("/NonExistentGroup", Data=sample_tensor)
 
 
 # Only run the tests in this file if it is run directly

--- a/tests/data/datacontainer/test_data_container.py
+++ b/tests/data/datacontainer/test_data_container.py
@@ -294,6 +294,43 @@ def test_set_dataset_existing_with_none(empty_container: DataContainer, sample_t
     assert result.shape == torch.empty(0).shape
 
 
+def test_set_attribute_existing_type_change_raises(empty_container: DataContainer):
+    """Test set_attribute raises TypeError when type changes with check_type=True (default)."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attribute("/TestGroup", "my_attr", "string_value")
+
+    with pytest.raises(TypeError):
+        empty_container.set_attribute("/TestGroup", "my_attr", 123)
+
+
+def test_set_attribute_existing_type_change_allowed(empty_container: DataContainer):
+    """Test set_attribute allows type change when check_type=False."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attribute("/TestGroup", "my_attr", "string_value")
+
+    empty_container.set_attribute("/TestGroup", "my_attr", 123, check_type=False)
+    assert empty_container.get_attribute("/TestGroup", "my_attr") == 123
+
+
+def test_set_attributes_type_change_raises(empty_container: DataContainer):
+    """Test set_attributes raises TypeError when type changes with check_type=True (default)."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attributes("/TestGroup", attr1="string_value", attr2=42)
+
+    with pytest.raises(TypeError):
+        empty_container.set_attributes("/TestGroup", check_type=True, attr1=999)
+
+
+def test_set_attributes_type_change_allowed(empty_container: DataContainer):
+    """Test set_attributes allows type changes when check_type=False."""
+    empty_container.add_group("/", "TestGroup")
+    empty_container.add_attributes("/TestGroup", attr1="string_value", attr2=42)
+
+    empty_container.set_attributes("/TestGroup", check_type=False, attr1=999, attr2="new_string")
+    assert empty_container.get_attribute("/TestGroup", "attr1") == 999
+    assert empty_container.get_attribute("/TestGroup", "attr2") == "new_string"
+
+
 # Only run the tests in this file if it is run directly
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_data_container.py
+++ b/tests/data/datacontainer/test_data_container.py
@@ -276,6 +276,24 @@ def test_set_datasets_parent_group_not_exist(empty_container: DataContainer, sam
         empty_container.set_datasets("/NonExistentGroup", Data=sample_tensor)
 
 
+def test_set_dataset_new_with_none(empty_container: DataContainer):
+    """Test set_dataset creates empty dataset when data is None and dataset does not exist."""
+    empty_container.set_dataset("/", "EmptyData", None)
+    assert "EmptyData" in empty_container.get_all_dataset_names()
+    result = empty_container.get_dataset("/EmptyData")
+    assert result.shape == torch.empty(0).shape
+
+
+def test_set_dataset_existing_with_none(empty_container: DataContainer, sample_tensor: Tensor):
+    """Test set_dataset sets data to empty when data is None and dataset exists."""
+    empty_container.add_dataset("/", "ExistingData", sample_tensor)
+    assert torch.equal(empty_container.get_dataset("/ExistingData"), sample_tensor)
+
+    empty_container.set_dataset("/", "ExistingData", None)
+    result = empty_container.get_dataset("/ExistingData")
+    assert result.shape == torch.empty(0).shape
+
+
 # Only run the tests in this file if it is run directly
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_data_container.py
+++ b/tests/data/datacontainer/test_data_container.py
@@ -329,8 +329,3 @@ def test_set_attributes_type_change_allowed(empty_container: DataContainer):
     empty_container.set_attributes("/TestGroup", check_type=False, attr1=999, attr2="new_string")
     assert empty_container.get_attribute("/TestGroup", "attr1") == 999
     assert empty_container.get_attribute("/TestGroup", "attr2") == "new_string"
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_dataset_ops.py
+++ b/tests/data/datacontainer/test_dataset_ops.py
@@ -629,8 +629,3 @@ def test_update_datasets_non_existing(
     # Assert that the expected error is raised
     with pytest.raises(expected_error):
         dataset_container.update_datasets(*update_data)
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_group_ops.py
+++ b/tests/data/datacontainer/test_group_ops.py
@@ -136,8 +136,3 @@ def test_remove_group_with_datasets(empty_container: DataContainer, sample_tenso
     # Verify group and dataset were removed
     assert "/group1" not in empty_container.nodes.keys()
     assert "/group1/dataset1" not in empty_container.nodes.keys()
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_node.py
+++ b/tests/data/datacontainer/test_node.py
@@ -289,8 +289,3 @@ def test_node_type_enum():
     assert NodeType.ROOT.value == "root"
     assert NodeType.GROUP.value == "group"
     assert NodeType.DATASET.value == "dataset"
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/datacontainer/test_utils.py
+++ b/tests/data/datacontainer/test_utils.py
@@ -106,8 +106,3 @@ def test_validate_paths_returns_normalized_tuple():
     """Test validate_paths returns normalized tuple values."""
     result = validate_paths(["Data/Tdata", "/MetaData/"])
     assert result == ("/Data/Tdata", "/MetaData")
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])

--- a/tests/data/test_thermo_container.py
+++ b/tests/data/test_thermo_container.py
@@ -1,4 +1,3 @@
-import pytest
 from torch import Tensor
 
 from pythermondt.data import ThermoContainer
@@ -42,8 +41,3 @@ def test_attribute_operations(thermo_container: ThermoContainer):
     teststring = "Test_value"
     thermo_container.add_attribute("/MetaData/DomainValues", "Test_attr", teststring)
     assert thermo_container.get_attribute("/MetaData/DomainValues", "Test_attr") == teststring
-
-
-# Only run the tests in this file if it is run directly
-if __name__ == "__main__":
-    pytest.main(["-v", __file__])


### PR DESCRIPTION
- Add `set_attribute` and `set_attributes` methods to add or update attributes (create new if missing, update existing)
- Add `set_dataset` and `set_datasets` methods to add or update datasets (create new if missing, update existing)
- Extend `NodeAccessor` with `__contains__` method to enable `in` keyword support for checking node existence
- Add comprehensive tests covering new, existing, and mixed scenarios for all set operations

These changes let users set datasets and attributes without first checking for existence, simplifying container manipulation code.