### PR TITLE
Refactor visualization ops with input validation, configurable overlays, and tests

### DIFF
--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -3,6 +3,7 @@ from typing import Literal, TypeAlias
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import ticker
+from matplotlib.colors import to_rgba
 from matplotlib.lines import Line2D
 from matplotlib.offsetbox import AnnotationBbox, TextArea
 from matplotlib.widgets import Button, CheckButtons, Slider
@@ -345,8 +346,12 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
                     frame_ax.imshow(overlay, aspect="auto", interpolation="none")
 
-                    # Add contour outline for defect boundaries
-                    frame_ax.contour(binary_gt.astype(float), levels=[0.5], colors="darkred", linewidths=1.5)
+                    # Compute darker version of overlay color for contour
+                    r, g, b, _ = to_rgba(overlay_color)
+                    contour_color = (r * 0.6, g * 0.6, b * 0.6)
+
+                    # Add contour outline for defect boundaries (darker than overlay)
+                    frame_ax.contour(binary_gt.astype(float), levels=[0.5], colors=[contour_color], linewidths=1.5)
 
                 plt.colorbar(im, ax=frame_ax, format=ticker.ScalarFormatter(useMathText=False, useOffset=False))
 

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -285,10 +285,11 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                 Options are "ShowGroundTruth", "OverlayGroundTruth", or an empty string.
             cmap (str): The color map to use for the visualization. Defaults to "plasma".
             overlay_color (OverlayColorOption): Color for the ground truth overlay. Defaults to "red".
-            overlay_alpha (float): Opacity for the ground truth overlay. Defaults to 0.6.
+            overlay_alpha (float): Opacity for the ground truth overlay, in the range [0, 1]. Defaults to 0.6.
 
         Raises:
             ValueError: If frame_number is out of valid range.
+            ValueError: If overlay_alpha is not in the range [0, 1].
         """
         data = self.get_dataset("/Data/Tdata")
         groundtruth = self.get_dataset("/GroundTruth/DefectMask")
@@ -327,6 +328,10 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
                 im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)
                 frame_ax.set_title(f"Frame {frame_number}")
+
+                # Validate alpha range
+                if not 0 <= overlay_alpha <= 1:
+                    raise ValueError(f"Overlay alpha must be in the range [0, 1], got {overlay_alpha}")
 
                 if groundtruth is not None:
                     # Convert to numpy for matplotlib compatibility

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -1,3 +1,5 @@
+from typing import Literal, TypeAlias
+
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
@@ -10,6 +12,9 @@ from ..units import generate_label
 from .attribute_ops import AttributeOps
 from .dataset_ops import DatasetOps
 from .group_ops import GroupOps
+
+# Type aliases for visualization options
+FrameOption: TypeAlias = Literal["ShowGroundTruth", "OverlayGroundTruth", ""]
 
 
 class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
@@ -262,7 +267,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
             self.fig.canvas.draw_idle()
 
-    def show_frame(self, frame_number: int, option: str = "", cmap: str = "plasma"):
+    def show_frame(self, frame_number: int, option: FrameOption = "", cmap: str = "plasma"):
         """Visualize a specific frame from the dataset with optional ground truth visualization and color mapping.
 
         Args:

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -337,10 +337,10 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                 Must be within the dataset's second dimension range.
             pixel_pos_y (int): The Y-coordinate (row index) of the pixel.
                 Must be within the dataset's first dimension range.
-        """
-        # Clear the current figure
-        plt.clf()
 
+        Raises:
+            ValueError: If pixel position is outside valid data bounds.
+        """
         # Extract the data from the container
         data = self.get_dataset("/Data/Tdata")
         domainvalues = self.get_dataset("/MetaData/DomainValues")
@@ -348,8 +348,9 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         domain_unit = self.get_unit("/MetaData/DomainValues")
 
         # Validate pixel positions to be within the data dimensions
-        if pixel_pos_x < 0 or pixel_pos_y < 0 or pixel_pos_x >= data.shape[0] or pixel_pos_y >= data.shape[1]:
-            raise ValueError("Pixel positions must be within the range of data dimensions.")
+        height, width = data.shape[:2]
+        if not (0 <= pixel_pos_x < width and 0 <= pixel_pos_y < height):
+            raise ValueError(f"Pixel ({pixel_pos_x}, {pixel_pos_y}) out of bounds [{width}x{height}]")
 
         # Extract temperature profile of the pixel
         temperature_profile = data[pixel_pos_y, pixel_pos_x, :]

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -300,7 +300,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             raise ValueError(f"Frame {frame_number} out of range [0, {total_frames})")
 
         # Get the frame to show
-        data_to_show = data[:, :, frame_number]
+        data_to_show = data[:, :, frame_number].numpy(force=True)
 
         # Show the frame with the selected option
         match option:
@@ -314,7 +314,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                 # Display the frame and ground truth
                 im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)
                 frame_ax.set_title(f"Frame {frame_number}")
-                gt_ax.imshow(groundtruth, aspect="auto")
+                gt_ax.imshow(groundtruth.numpy(force=True), aspect="auto")
                 gt_ax.set_title("Ground Truth")
 
                 # Attach colorbar tightly to the thermal image
@@ -402,7 +402,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         temperature_profile = data[pixel_pos_y, pixel_pos_x, :]
 
         # Plot the temperature profile
-        plt.plot(domainvalues, temperature_profile)
+        plt.plot(domainvalues.numpy(force=True), temperature_profile.numpy(force=True))
         plt.title(f"Profile of Pixel: {pixel_pos_x},{pixel_pos_y}")
         plt.xlabel(generate_label(domain_unit))
         plt.ylabel(generate_label(data_unit))

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -272,16 +272,20 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
         Args:
             frame_number (int): The frame number to visualize.
-            option (str): The visualization option to apply.
+            option (FrameOption): The visualization option to apply.
                 Options are "ShowGroundTruth", "OverlayGroundTruth", or an empty string.
-            cmap (str): The color map to use for the visualization. Defaults to 'plasma'.
-        """
-        # Clear current figure
-        plt.clf()
+            cmap (str): The color map to use for the visualization. Defaults to "plasma".
 
-        # Extract the data from the container
+        Raises:
+            ValueError: If frame_number is out of valid range.
+        """
         data = self.get_dataset("/Data/Tdata")
         groundtruth = self.get_dataset("/GroundTruth/DefectMask")
+
+        # Validate frame number
+        total_frames = data.shape[2]
+        if not 0 <= frame_number < total_frames:
+            raise ValueError(f"Frame {frame_number} out of range [0, {total_frames})")
 
         # Get the frame to show
         data_to_show = data[:, :, frame_number]

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -2,7 +2,6 @@ from typing import Literal, TypeAlias
 
 import matplotlib.pyplot as plt
 import numpy as np
-import torch
 from matplotlib import ticker
 from matplotlib.lines import Line2D
 from matplotlib.offsetbox import AnnotationBbox, TextArea
@@ -315,17 +314,24 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             case "OverlayGroundTruth":
                 _, frame_ax = plt.subplots(figsize=(7, 6))
 
-                im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)  # Display the original data
+                im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)
                 frame_ax.set_title(f"Frame {frame_number}")
 
                 if groundtruth is not None:
-                    # Prepare the overlay
-                    binary_gt = groundtruth > 0  # Create a binary mask of the ground truth
-                    rows, cols = groundtruth.shape
-                    gt_overlay = torch.zeros((rows, cols, 3))  # Initialize an all-zero RGB image for the overlay
-                    gt_overlay[:, :, 1] = binary_gt  # Apply green in the binary mask areas
+                    # Convert to numpy for matplotlib compatibility
+                    gt: np.ndarray = groundtruth.numpy(force=True)
+                    binary_gt: np.ndarray = gt > 0
 
-                    frame_ax.imshow(gt_overlay, alpha=0.5)  # Display overlay with transparency
+                    # Create RGBA overlay: red with 60% opacity
+                    rows, cols = binary_gt.shape
+                    overlay = np.zeros((rows, cols, 4))  # RGBA
+                    overlay[binary_gt, 0] = 1.0  # Red channel
+                    overlay[binary_gt, 3] = 0.5  # Alpha channel
+
+                    frame_ax.imshow(overlay, aspect="auto", interpolation="none")
+
+                    # Add contour outline for defect boundaries
+                    frame_ax.contour(binary_gt.astype(float), levels=[0.5], colors="darkred", linewidths=1.5)
 
                 plt.colorbar(im, ax=frame_ax, format=ticker.ScalarFormatter(useMathText=False, useOffset=False))
 

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -289,6 +289,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
         Raises:
             ValueError: If frame_number is out of valid range.
+            ValueError: If overlay_color is not one of "red", "green", "blue".
             ValueError: If overlay_alpha is not in the range [0, 1].
         """
         data = self.get_dataset("/Data/Tdata")
@@ -329,7 +330,9 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                 im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)
                 frame_ax.set_title(f"Frame {frame_number}")
 
-                # Validate alpha range
+                # Validate overlay parameters
+                if overlay_color not in {"red", "green", "blue"}:
+                    raise ValueError(f"Invalid overlay_color '{overlay_color}'. Must be one of: red, green, blue")
                 if not 0 <= overlay_alpha <= 1:
                     raise ValueError(f"Overlay alpha must be in the range [0, 1], got {overlay_alpha}")
 

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -15,6 +15,7 @@ from .group_ops import GroupOps
 
 # Type aliases for visualization options
 FrameOption: TypeAlias = Literal["ShowGroundTruth", "OverlayGroundTruth", ""]
+OverlayColorOption: TypeAlias = Literal["red", "green", "blue"]
 
 
 class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
@@ -267,7 +268,14 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
             self.fig.canvas.draw_idle()
 
-    def show_frame(self, frame_number: int, option: FrameOption = "", cmap: str = "plasma"):
+    def show_frame(
+        self,
+        frame_number: int,
+        option: FrameOption = "",
+        cmap: str = "plasma",
+        overlay_color: OverlayColorOption = "red",
+        overlay_alpha: float = 0.6,
+    ):
         """Visualize a specific frame from the dataset with optional ground truth visualization and color mapping.
 
         Args:
@@ -275,6 +283,8 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             option (FrameOption): The visualization option to apply.
                 Options are "ShowGroundTruth", "OverlayGroundTruth", or an empty string.
             cmap (str): The color map to use for the visualization. Defaults to "plasma".
+            overlay_color (OverlayColorOption): Color for the ground truth overlay. Defaults to "red".
+            overlay_alpha (float): Opacity for the ground truth overlay. Defaults to 0.6.
 
         Raises:
             ValueError: If frame_number is out of valid range.
@@ -322,11 +332,16 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                     gt: np.ndarray = groundtruth.numpy(force=True)
                     binary_gt: np.ndarray = gt > 0
 
-                    # Create RGBA overlay: red with 60% opacity
+                    # Create RGBA overlay with configurable color and alpha
                     rows, cols = binary_gt.shape
                     overlay = np.zeros((rows, cols, 4))  # RGBA
-                    overlay[binary_gt, 0] = 1.0  # Red channel
-                    overlay[binary_gt, 3] = 0.5  # Alpha channel
+                    if overlay_color == "red":
+                        overlay[binary_gt, 0] = 1.0  # Red channel
+                    elif overlay_color == "green":
+                        overlay[binary_gt, 1] = 1.0  # Green channel
+                    elif overlay_color == "blue":
+                        overlay[binary_gt, 2] = 1.0  # Blue channel
+                    overlay[binary_gt, 3] = overlay_alpha  # Alpha channel
 
                     frame_ax.imshow(overlay, aspect="auto", interpolation="none")
 

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -7,6 +7,7 @@ from matplotlib import ticker
 from matplotlib.lines import Line2D
 from matplotlib.offsetbox import AnnotationBbox, TextArea
 from matplotlib.widgets import Button, CheckButtons, Slider
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ..units import generate_label
 from .attribute_ops import AttributeOps
@@ -293,17 +294,29 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         # Show the frame with the selected option
         match option:
             case "ShowGroundTruth":
-                plt.subplot(1, 2, 1)
-                image = plt.imshow(data_to_show, aspect="auto", cmap=cmap)
-                plt.title(f"Frame Number: {frame_number}")
+                # Create a figure with two subplots: one for the frame and one for the ground truth
+                fig = plt.figure(figsize=(11, 5.5), layout="constrained")
+                gs = fig.add_gridspec(1, 2, width_ratios=[1, 1], wspace=0.2)
+                frame_ax = fig.add_subplot(gs[0])
+                gt_ax = fig.add_subplot(gs[1])
 
-                plt.subplot(1, 2, 2)
-                plt.imshow(groundtruth, aspect="auto")
-                plt.title("Ground Truth")
+                # Display the frame and ground truth
+                im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)
+                frame_ax.set_title(f"Frame {frame_number}")
+                gt_ax.imshow(groundtruth, aspect="auto")
+                gt_ax.set_title("Ground Truth")
+
+                # Attach colorbar tightly to the thermal image
+                divider = make_axes_locatable(frame_ax)
+                cbar_ax = divider.append_axes("right", size="8%", pad=0.16)
+                cbar = fig.colorbar(im, cax=cbar_ax, format=ticker.ScalarFormatter(useMathText=False, useOffset=False))
+                cbar.ax.tick_params(pad=4)
 
             case "OverlayGroundTruth":
-                image = plt.imshow(data_to_show, aspect="auto", cmap=cmap)  # Display the original data
-                plt.title(f"Frame Number: {frame_number}")
+                _, frame_ax = plt.subplots(figsize=(7, 6))
+
+                im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)  # Display the original data
+                frame_ax.set_title(f"Frame {frame_number}")
 
                 if groundtruth is not None:
                     # Prepare the overlay
@@ -312,18 +325,20 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                     gt_overlay = torch.zeros((rows, cols, 3))  # Initialize an all-zero RGB image for the overlay
                     gt_overlay[:, :, 1] = binary_gt  # Apply green in the binary mask areas
 
-                    plt.imshow(gt_overlay, alpha=0.5)  # Display overlay with transparency
+                    frame_ax.imshow(gt_overlay, alpha=0.5)  # Display overlay with transparency
+
+                plt.colorbar(im, ax=frame_ax, format=ticker.ScalarFormatter(useMathText=False, useOffset=False))
 
             # Default case, just show the frame data
             case _:
-                image = plt.imshow(data_to_show, aspect="auto", cmap=cmap)
-                plt.title(f"Frame Number: {frame_number}")
+                _, frame_ax = plt.subplots(figsize=(7, 6))
 
-        # Custom formatter for the colorbar to ensure that the colorbar ticks are displayed without offset
-        formatter = ticker.ScalarFormatter(useMathText=False, useOffset=False)
+                im = frame_ax.imshow(data_to_show, aspect="auto", cmap=cmap)
+                frame_ax.set_title(f"Frame {frame_number}")
+
+                plt.colorbar(im, ax=frame_ax, format=ticker.ScalarFormatter(useMathText=False, useOffset=False))
 
         # Show the plot
-        plt.colorbar(image, format=formatter)
         plt.show()
 
     def show_pixel_profile(self, pixel_pos_x: int, pixel_pos_y: int):

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -276,7 +276,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         cmap: str = "plasma",
         overlay_color: OverlayColorOption = "red",
         overlay_alpha: float = 0.6,
-    ):
+    ):  # pylint: disable=too-many-locals
         """Visualize a specific frame from the dataset with optional ground truth visualization and color mapping.
 
         Args:

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -1,3 +1,4 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from matplotlib.collections import Collection
@@ -63,8 +64,6 @@ def test_alpha_valid(thermo_container: ThermoContainer, alpha):
 
 def test_default_mode_figure(thermo_container: ThermoContainer):
     """Default mode creates figure with correct size, title, and colorbar."""
-    import matplotlib.pyplot as plt
-
     thermo_container.show_frame(0)
 
     fig = plt.gcf()
@@ -76,8 +75,6 @@ def test_default_mode_figure(thermo_container: ThermoContainer):
 
 def test_show_ground_truth_figure(thermo_container: ThermoContainer):
     """ShowGroundTruth mode creates two subplots with correct titles."""
-    import matplotlib.pyplot as plt
-
     thermo_container.show_frame(0, option="ShowGroundTruth")
 
     fig = plt.gcf()
@@ -89,8 +86,6 @@ def test_show_ground_truth_figure(thermo_container: ThermoContainer):
 
 def test_overlay_mode_figure(thermo_container: ThermoContainer):
     """OverlayGroundTruth mode creates figure with colorbar."""
-    import matplotlib.pyplot as plt
-
     thermo_container.show_frame(0, option="OverlayGroundTruth")
 
     fig = plt.gcf()
@@ -103,8 +98,6 @@ def test_overlay_mode_figure(thermo_container: ThermoContainer):
 def test_overlay_rgba_channel(thermo_container: ThermoContainer, color):
     """Each overlay color activates the correct RGBA channel."""
     thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_color=color)
-
-    import matplotlib.pyplot as plt
 
     fig = plt.gcf()
     ax = fig.axes[0]
@@ -137,8 +130,6 @@ def test_overlay_contour_color(thermo_container: ThermoContainer, color):
     expected_contour = (expected_r * 0.6, expected_g * 0.6, expected_b * 0.6)
 
     thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_color=color)
-
-    import matplotlib.pyplot as plt
 
     fig = plt.gcf()
     ax = fig.axes[0]

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -24,6 +24,10 @@ def _setup_matplotlib(monkeypatch):
 
     matplotlib.use("Agg")
     monkeypatch.setattr("matplotlib.pyplot.show", lambda *args, **kwargs: None)
+    yield
+    import matplotlib.pyplot as plt
+
+    plt.close("all")
 
 
 def test_frame_number_negative(thermo_container: ThermoContainer):
@@ -60,6 +64,19 @@ def test_alpha_out_of_range(thermo_container: ThermoContainer, alpha):
 def test_alpha_valid(thermo_container: ThermoContainer, alpha):
     """Overlay alpha within [0, 1] does not raise."""
     thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_alpha=alpha)
+
+
+@pytest.mark.parametrize("color", ["purple", "yellow", "cyan", ""])
+def test_overlay_color_invalid(thermo_container: ThermoContainer, color):
+    """Unsupported overlay color raises ValueError."""
+    with pytest.raises(ValueError, match=r"Invalid overlay_color"):
+        thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_color=color)
+
+
+@pytest.mark.parametrize("color", ["red", "green", "blue"])
+def test_overlay_color_valid(thermo_container: ThermoContainer, color):
+    """Valid overlay colors do not raise."""
+    thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_color=color)
 
 
 def test_default_mode_figure(thermo_container: ThermoContainer):

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -1,0 +1,180 @@
+import numpy as np
+import pytest
+from matplotlib.collections import Collection
+from matplotlib.colors import to_rgba
+
+from pythermondt.data import ThermoContainer
+from pythermondt.readers import LocalReader
+
+
+@pytest.fixture(scope="module")
+def thermo_container() -> ThermoContainer:
+    """ThermoContainer with simulation data including defect mask for visualization tests."""
+    reader = LocalReader(pattern="./tests/assets/integration/simulation/source2.mat")
+    container = next(iter(reader))
+    assert isinstance(container, ThermoContainer)
+    return container
+
+
+@pytest.fixture(autouse=True)
+def _setup_matplotlib(monkeypatch):
+    """Use Agg backend and disable plt.show for all visualization tests."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    monkeypatch.setattr("matplotlib.pyplot.show", lambda *args, **kwargs: None)
+
+
+def test_frame_number_negative(thermo_container: ThermoContainer):
+    """Negative frame number raises ValueError."""
+    with pytest.raises(ValueError, match=r"Frame -1 out of range \[0, \d+\)"):
+        thermo_container.show_frame(-1)
+
+
+def test_frame_number_out_of_range(thermo_container: ThermoContainer):
+    """Frame number >= total frames raises ValueError."""
+    total = thermo_container.get_dataset("/Data/Tdata").shape[2]
+    with pytest.raises(ValueError, match=rf"Frame {total} out of range \[0, {total}\)"):
+        thermo_container.show_frame(total)
+
+
+@pytest.mark.parametrize("frame", [0, "last"])
+def test_frame_number_valid(thermo_container: ThermoContainer, frame):
+    """Valid frame numbers (first, last) do not raise."""
+    if isinstance(frame, int):
+        fn = frame
+    else:
+        fn = thermo_container.get_dataset("/Data/Tdata").shape[2] - 1
+    thermo_container.show_frame(fn)
+
+
+@pytest.mark.parametrize("alpha", [-0.1, 1.1, -0.5, 1.5])
+def test_alpha_out_of_range(thermo_container: ThermoContainer, alpha):
+    """Overlay alpha outside [0, 1] raises ValueError."""
+    with pytest.raises(ValueError, match=r"Overlay alpha must be in the range \[0, 1\], got"):
+        thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_alpha=alpha)
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.0, 0.6])
+def test_alpha_valid(thermo_container: ThermoContainer, alpha):
+    """Overlay alpha within [0, 1] does not raise."""
+    thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_alpha=alpha)
+
+
+def test_default_mode_figure(thermo_container: ThermoContainer):
+    """Default mode creates figure with correct size, title, and colorbar."""
+    import matplotlib.pyplot as plt
+
+    thermo_container.show_frame(0)
+
+    fig = plt.gcf()
+    assert fig.get_size_inches() == pytest.approx((7, 6))
+    ax = fig.axes[0]
+    assert ax.get_title() == "Frame 0"
+    assert len(fig.axes) >= 1  # frame axis exists
+
+
+def test_show_ground_truth_figure(thermo_container: ThermoContainer):
+    """ShowGroundTruth mode creates two subplots with correct titles."""
+    import matplotlib.pyplot as plt
+
+    thermo_container.show_frame(0, option="ShowGroundTruth")
+
+    fig = plt.gcf()
+    assert fig.get_size_inches() == pytest.approx((11, 5.5))
+    assert len(fig.axes) >= 2  # Both subplots present
+    assert fig.axes[0].get_title() == "Frame 0"
+    assert fig.axes[1].get_title() == "Ground Truth"
+
+
+def test_overlay_mode_figure(thermo_container: ThermoContainer):
+    """OverlayGroundTruth mode creates figure with colorbar."""
+    import matplotlib.pyplot as plt
+
+    thermo_container.show_frame(0, option="OverlayGroundTruth")
+
+    fig = plt.gcf()
+    assert fig.get_size_inches() == pytest.approx((7, 6))
+    ax = fig.axes[0]
+    assert ax.get_title() == "Frame 0"
+
+
+@pytest.mark.parametrize("color", ["red", "green", "blue"])
+def test_overlay_rgba_channel(thermo_container: ThermoContainer, color):
+    """Each overlay color activates the correct RGBA channel."""
+    thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_color=color)
+
+    import matplotlib.pyplot as plt
+
+    fig = plt.gcf()
+    ax = fig.axes[0]
+    overlay_images = [im for im in ax.get_images() if (arr := im.get_array()) is not None and arr.shape[-1] == 4]
+    assert len(overlay_images) == 1, f"Expected 1 RGBA overlay image, got {len(overlay_images)}"
+
+    overlay_array = overlay_images[0].get_array()
+    assert overlay_array is not None
+    assert overlay_array.ndim == 3 and overlay_array.shape[2] == 4  # HxWx4
+
+    channel_idx = {"red": 0, "green": 1, "blue": 2}[color]
+
+    # Defect pixels (gt > 0) should have the correct channel set to 1.0
+    gt = thermo_container.get_dataset("/GroundTruth/DefectMask").numpy(force=True)
+    defect_mask = gt > 0
+
+    if defect_mask.any():
+        channel_values = overlay_array[defect_mask, channel_idx]
+        assert np.allclose(channel_values, 1.0), f"{color} channel not set on defect pixels"
+
+        # Non-defect pixels should have all channels at 0 (fully transparent)
+        non_defect_mask = ~defect_mask
+        assert np.allclose(overlay_array[non_defect_mask, :], 0.0), "Non-defect pixels should be transparent"
+
+
+@pytest.mark.parametrize("color", ["red", "green", "blue"])
+def test_overlay_contour_color(thermo_container: ThermoContainer, color):
+    """Contour color should be 0.6x darker than the overlay color."""
+    expected_r, expected_g, expected_b, _ = to_rgba(color)
+    expected_contour = (expected_r * 0.6, expected_g * 0.6, expected_b * 0.6)
+
+    thermo_container.show_frame(0, option="OverlayGroundTruth", overlay_color=color)
+
+    import matplotlib.pyplot as plt
+
+    fig = plt.gcf()
+    ax = fig.axes[0]
+    contours = list(ax.collections)  # Contour adds LineCollection objects to the axis
+    if contours:
+        first: Collection = contours[0]
+        if hasattr(first, "get_colors"):
+            actual_colors = first.get_colors()
+            if len(actual_colors) > 0:
+                actual = actual_colors[0][:3]
+                assert np.allclose(actual, expected_contour, atol=0.01), (
+                    f"Contour color {actual} does not match expected {expected_contour}"
+                )
+
+
+def test_coordinate_negative_x(thermo_container: ThermoContainer):
+    """Negative X coordinate raises ValueError."""
+    with pytest.raises(ValueError, match=r"Pixel \(-1, 0\) out of bounds"):
+        thermo_container.show_pixel_profile(-1, 0)
+
+
+def test_coordinate_negative_y(thermo_container: ThermoContainer):
+    """Negative Y coordinate raises ValueError."""
+    with pytest.raises(ValueError, match=r"Pixel \(0, -1\) out of bounds"):
+        thermo_container.show_pixel_profile(0, -1)
+
+
+def test_coordinate_out_of_range(thermo_container: ThermoContainer):
+    """Coordinate beyond data dimensions raises ValueError."""
+    data = thermo_container.get_dataset("/Data/Tdata")
+    width, height = data.shape[1], data.shape[0]
+    with pytest.raises(ValueError, match=rf"Pixel \({width}, {height}\) out of bounds"):
+        thermo_container.show_pixel_profile(width, height)
+
+
+@pytest.mark.parametrize("x, y", [(0, 0), (50, 50)])
+def test_coordinate_valid(thermo_container: ThermoContainer, x, y):
+    """Valid coordinates do not raise."""
+    thermo_container.show_pixel_profile(x, y)

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -1,8 +1,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from matplotlib.collections import Collection
 from matplotlib.colors import to_rgba
+from matplotlib.contour import QuadContourSet
 
 from pythermondt.data import ThermoContainer
 from pythermondt.readers import LocalReader
@@ -126,6 +126,7 @@ def test_overlay_rgba_channel(thermo_container: ThermoContainer, color):
 @pytest.mark.parametrize("color", ["red", "green", "blue"])
 def test_overlay_contour_color(thermo_container: ThermoContainer, color):
     """Contour color should be 0.6x darker than the overlay color."""
+    # Calculate expected contour color as 0.6 times the RGBA values of the overlay color
     expected_r, expected_g, expected_b, _ = to_rgba(color)
     expected_contour = (expected_r * 0.6, expected_g * 0.6, expected_b * 0.6)
 
@@ -133,16 +134,20 @@ def test_overlay_contour_color(thermo_container: ThermoContainer, color):
 
     fig = plt.gcf()
     ax = fig.axes[0]
-    contours = list(ax.collections)  # Contour adds LineCollection objects to the axis
-    if contours:
-        first: Collection = contours[0]
-        if hasattr(first, "get_colors"):
-            actual_colors = first.get_colors()
-            if len(actual_colors) > 0:
-                actual = actual_colors[0][:3]
-                assert np.allclose(actual, expected_contour, atol=0.01), (
-                    f"Contour color {actual} does not match expected {expected_contour}"
-                )
+    # Contour adds QuadContourSet collections to the axis
+    contours = list(ax.collections)
+    assert contours, "Expected contour collections not found in the plot"
+    assert all(isinstance(c, QuadContourSet) for c in contours), "Expected contour collections to be QuadContourSet"
+
+    # Extract the first contour set and check its color
+    first = contours[0]
+    assert isinstance(first, QuadContourSet), f"Expected a QuadContourSet, got {type(first)}"
+    actual_colors = first.colors
+    assert isinstance(actual_colors, list), "Expected contour colors to be defined"
+    actual = actual_colors[0][:3]
+    assert np.allclose(actual, expected_contour, atol=0.01), (
+        f"Contour color {actual} does not match expected {expected_contour}"
+    )
 
 
 def test_coordinate_negative_x(thermo_container: ThermoContainer):


### PR DESCRIPTION
- Add typed `FrameOption` and `OverlayColorOption` aliases for clearer parameter intent
- Validate `frame_number`, `overlay_alpha`, and `pixel_pos` ranges — raise descriptive `ValueError` on invalid input
- Refactor `show_frame()` layout: explicit figure/axis creation, `GridSpec` for `ShowGroundTruth` subplots, tight colorbars via `make_axes_locatable`
- Replace hardcoded green overlay with configurable RGBA overlay (`overlay_color` red/green/blue, `overlay_alpha`) and contour outlines at 60% shade
- Add 25 tests in `tests/data/datacontainer/test_visualization_ops.py` covering all new validation and output behavior

The visualization API now guards against invalid inputs, produces consistent layouts, and has test coverage for both validation paths and rendered output properties.