### PR TITLE
Clean up typos, remove debug prints, and consolidate agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,133 +1,42 @@
-# PyThermoNDT AI Coding Instructions
+# PyThermoNDT Copilot Instructions
 
-PyThermoNDT is a PyTorch-compatible package for thermographic data processing in Non-Destructive Testing (NDT). This guide helps AI agents understand the essential architecture and patterns for immediate productivity.
+This file is kept because GitHub Copilot uses `.github/copilot-instructions.md` as repository-wide custom instructions. For project architecture, coding style, and domain rules, follow `AGENTS.md` first.
 
-## Core Architecture Pattern
+Keep this file intentionally concise.
 
-**Data Flow:** Readers → DataContainers → Transforms → Datasets → PyTorch DataLoaders
+- Include only non-obvious, high-value guidance.
+- Prefer concrete rules and style references over repository overviews.
+- Do not duplicate documentation that is easy to discover elsewhere in the repo.
 
-1. **Readers** (`src/pythermondt/readers/`) coordinate Backends (I/O) + Parsers (format conversion)
-2. **DataContainers** (`src/pythermondt/data/datacontainer/`) provide hierarchical HDF5-like data structure
-3. **Transforms** (`src/pythermondt/transforms/`) are PyTorch nn.Modules for processing pipelines
-4. **Datasets** (`src/pythermondt/dataset/`) bridge to PyTorch DataLoader interface
+Match the coding style of these reference implementations:
 
-## Essential DataContainer Structure
+- `src/pythermondt/transforms/sampling.py` - `NonUniformSampling`
+- `src/pythermondt/dataset/base_dataset.py` - `BaseDataset`
 
-All thermal data follows standardized ThermoContainer hierarchy:
-```
-/Data/Tdata               # Raw thermal data (H×W×T tensors)
-/GroundTruth/DefectMask   # Binary defect masks
-/MetaData/LookUpTable     # Temperature conversion
-/MetaData/DomainValues    # Time values for frames
-/MetaData/ExcitationSignal # Heating pattern
-```
+Default style expectations:
 
-**Key API Pattern:**
-```python
-# Extract datasets
-tdata, domain_values = container.get_datasets("/Data/Tdata", "/MetaData/DomainValues")
+- prefer minimal, linear implementations over extra abstraction
+- keep methods easy to scan: load -> validate -> compute -> update -> return
+- use helpful Google-style docstrings and sparse comments
+- validate early with descriptive errors
+- use concrete domain names instead of generic helper names
 
-# Process data
-processed_tdata = self._process(tdata)
+Project rules:
 
-# Update container (preserves hierarchy)
-container.update_datasets(("/Data/Tdata", processed_tdata))
-```
+- preserve temporal consistency across `/Data/Tdata`, `/MetaData/DomainValues`, and `/MetaData/ExcitationSignal`
+- update units when physical meaning changes
+- prefer tensor operations over Python loops
+- all functional changes must include tests
+- do not mix functionality and whitespace-only cleanup in the same commit
 
-## Transform Implementation Pattern
+Useful validation commands:
 
-All transforms inherit from `ThermoTransform` (deterministic) or `RandomThermoTransform` (stochastic):
-
-```python
-class MyTransform(ThermoTransform):
-    def __init__(self, param: int):
-        super().__init__()
-        self.param = param  # Store as instance attribute
-
-    def forward(self, container: DataContainer) -> DataContainer:
-        # Extract, process, update pattern
-        tdata = container.get_dataset("/Data/Tdata")
-        processed = self._process(tdata)
-        container.update_datasets(("/Data/Tdata", processed))
-        return container
-```
-
-**Critical Implementation Details:**
-- Use `container.get_datasets()` for multiple datasets in one call
-- Check time units: `container.get_unit("/MetaData/DomainValues")["quantity"] == "time"`
-- Validate tensor bounds: `idx < 0 or idx >= tdata.shape[-1]` raises `ValueError`
-- Frame operations must adjust domain values: `domain_values - domain_values[0]`
-
-## Development Workflow
-
-**Setup:**
 ```bash
-uv venv && uv pip install -e . && uv pip install -r requirements_dev.txt
-pre-commit install  # Essential - runs Ruff, mypy, typos
+pytest tests/
+pytest -k "test_name"
+pytest --benchmark-skip
+ruff check --fix .
+ruff format .
+mypy src/pythermondt
+pre-commit run --all-files
 ```
-
-**Testing Pattern:**
-```bash
-pytest tests/transforms/test_sampling.py  # Specific transform tests
-pytest -k "test_apply_lut"                # Pattern matching
-pytest tests/integration/                 # End-to-end workflows
-```
-
-**Code Quality:**
-- Ruff enforces 120-char lines, Google docstring style
-- Configuration in `pyproject.toml` with strict linting
-- Pre-commit hooks block commits with quality issues
-- Use `pytest.mark.parametrize` for multiple test scenarios
-
-## Project-Specific Conventions
-
-**Configuration:**
-- Global settings via `pythermondt.config.settings` (pydantic-settings)
-- Environment variables prefixed `PYTHERMONDT_` (e.g., `PYTHERMONDT_DOWNLOAD_DIR`)
-- Settings auto-create missing directories and validate worker counts
-
-**Unit Management:**
-- Use `Units` enum from `pythermondt.data.units`
-- LUT application changes Tdata units from `arbitrary` to `kelvin`
-- Transforms must preserve/update units appropriately
-
-**Error Patterns:**
-- `ValueError` for user input errors with descriptive messages
-- `IndexError` for frame index bounds violations
-- Validate tensor dimensions before operations
-
-**Performance Considerations:**
-- Use tensor operations over loops for frame processing
-- Leverage `settings.num_workers` for parallel operations
-- Consider memory usage for large H×W×T thermal sequences
-
-## File Organization Patterns
-
-**Test Structure:** Mirror source structure
-- `tests/transforms/test_sampling.py` tests `src/pythermondt/transforms/sampling.py`
-- Use fixtures from `tests/conftest.py` for common test data
-- Integration tests in `tests/integration/` for full workflows
-
-**Transform Categories:**
-- `preprocessing.py` - ApplyLUT, RemoveFlash, SubtractFrame
-- `sampling.py` - NonUniformSampling, SelectFrames, SelectFrameRange
-- `normalization.py` - MinMaxNormalize, ZScoreNormalize, MaxNormalize
-- `augmentation.py` - GaussianNoise, RandomFlip (stochastic transforms)
-
-## Critical Integration Points
-
-**PyTorch Compatibility:**
-- Transforms are `nn.Module` subclasses with proper `forward()` methods
-- Datasets implement `torch.utils.data.Dataset` interface
-- Use `container_collate()` function for DataLoader batching
-
-**AWS S3 Integration:**
-- S3Reader with boto3, supports download caching to `settings.download_dir`
-- Automatic backend selection (LocalBackend vs S3Backend)
-
-**Time Domain Handling:**
-- Always verify time units before temporal operations
-- Frame selection must maintain temporal consistency across Tdata, DomainValues, ExcitationSignal
-- Use `domain_values[selected_indices]` for frame subsets
-
-When implementing features, follow the modular Reader/Transform/Dataset pattern and ensure PyTorch ecosystem compatibility.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,126 @@
 # PyThermoNDT Agent Instructions
 
-Hello agent. You are one of the most talented programmers of your generation, ready to improve PyThermoNDT - a PyTorch-compatible package for thermographic Non-Destructive Testing (NDT) data processing.
+## Style Baseline
+
+Treat these as the canonical examples of the preferred style:
+
+- `src/pythermondt/transforms/sampling.py` - `NonUniformSampling`
+- `src/pythermondt/dataset/base_dataset.py` - `BaseDataset`
+
+New code should feel like those implementations on the first pass:
+
+- minimal, but not cryptic
+- readable from top to bottom
+- well documented, but only where documentation adds value
+- explicit about validation, assumptions, and update steps
+
+## Context File Scope
+
+Keep this file intentionally concise.
+
+- Include only non-obvious, high-value guidance that helps agents avoid mistakes in this repository.
+- Prefer concrete rules and reference implementations over broad repository overviews.
+- Do not restate information that is easy to discover from file names, README content, or normal code exploration.
+- If a rule is not important enough to be followed on most tasks, omit it.
 
 ## Philosophy
 
-- **Clarity over Complexity**: Every transform must earn its place in the pipeline
-- **Scientific Rigor**: Maintain physical accuracy in thermal data processing
-- **PyTorch Compatible**: Seamless integration with PyTorch workflows
-- **Never mix functionality and whitespace changes** - separate commits
-- **All functionality changes must include tests**
+- **Clarity over complexity**: Prefer direct control flow over clever abstractions.
+- **Scientific rigor**: Preserve the physical meaning of thermal data and metadata.
+- **PyTorch compatibility**: Keep transforms and datasets natural to use in PyTorch pipelines.
+- **Smallest correct change**: Do not add helpers, layers, or backward-compatibility code without a concrete need.
+- **No mixed commits**: Never mix functionality and whitespace-only cleanup in the same commit.
+- **Tests for behavior changes**: All functional changes must include tests.
 
 ## Architecture
 
-```
-Readers → DataContainers → Transforms → Datasets → PyTorch DataLoaders
-```
-
-**Tech Stack**: Python 3.10-3.14, PyTorch ≥2.0, NumPy, h5py, boto3 (S3), pytest, ruff, mypy
-
-### DataContainer Structure (Standard Paths)
-
-```
-/Data/Tdata                    # Thermal data (H×W×T)
-/GroundTruth/DefectMask        # Defect masks (H×W)
-/MetaData/LookUpTable          # Temperature conversion (Uint16→Float64)
-/MetaData/DomainValues         # Time values (T,)
-/MetaData/ExcitationSignal     # Heating pattern
+```text
+Readers -> DataContainers -> Transforms -> Datasets -> PyTorch DataLoaders
 ```
 
-**Access Pattern**:
+Tech stack: Python 3.10-3.14, PyTorch >= 2.0, NumPy, h5py, boto3, pytest, ruff, mypy
+
+### Standard DataContainer Paths
+
+```text
+/Data/Tdata                    # Thermal data (H x W x T)
+/GroundTruth/DefectMask        # Defect mask (H x W)
+/MetaData/LookUpTable          # Temperature conversion (uint16 -> float64)
+/MetaData/DomainValues         # Domain values, usually time (T,)
+/MetaData/ExcitationSignal     # Heating pattern (T,)
+```
+
+Use `container.get_datasets(...)` and `container.update_datasets(...)` when several paths move together.
+
+## Coding Style
+
+### Preferred Structure
+
+Inside a method, prefer a simple sequence like this:
+
+1. Load the relevant data.
+2. Validate inputs and invariants early.
+3. Compute the result with direct tensor operations.
+4. Update the container or return the result.
+
+That shape is preferred over deeply nested branches or many tiny helpers.
+
+### Helpers
+
+Extract a private helper only when it does at least one of these:
+
+- names a real domain concept
+- isolates dense math or interpolation logic
+- is reused
+- materially improves readability of the public method
+
+`NonUniformSampling` is a good model: the helper methods isolate non-trivial math, while `forward()` stays linear and readable.
+
+### Naming
+
+- Use concrete domain names: `domain_values`, `excitation_signal`, `det_transforms`, `runtime_transforms`.
+- Avoid vague names like `data2`, `temp`, `helper`, `manager2`, `process_data_wrapper`.
+- Keep public APIs boring and obvious.
+
+### Comments
+
+- Use comments sparingly.
+- Good comments explain why something is done or mark a phase boundary.
+- Do not narrate obvious lines.
+
+### Docstrings
+
+- Use Google-style docstrings.
+- Start with a short summary sentence.
+- Document intent, important constraints, and non-obvious behavior.
+- Document `Args`, `Returns`, and `Raises` when they add useful information.
+- Avoid docstrings that merely restate the code.
+
+### Errors and Validation
+
+- Validate dimensions, bounds, modes, and units at the start of the relevant method.
+- Raise descriptive exceptions with concrete context.
+
+Example:
+
 ```python
-# Get datasets (efficient for multiple)
-tdata, mask = container.get_datasets("/Data/Tdata", "/GroundTruth/DefectMask")
-
-# Update datasets
-container.update_datasets(
-    ("/Data/Tdata", processed_tdata),
-    ("/MetaData/DomainValues", new_domain_values)
-)
+if idx < 0 or idx >= len(self):
+    raise IndexError(f"Index {idx} out of range [0, {len(self) - 1}].")
 ```
+
+### Type Hints and Formatting
+
+- Use modern Python 3.10+ type hints: `list[str]`, `dict[str, float] | None`
+- Follow Ruff formatting and lint rules.
+- Use double quotes.
+- Keep lines within 120 characters.
+
+## Project Patterns
 
 ### Transform Pattern
 
 ```python
-class MyTransform(ThermoTransform):  # or RandomThermoTransform for stochastic
+class MyTransform(ThermoTransform):
     def __init__(self, param: int):
         super().__init__()
         self.param = param
@@ -51,136 +128,104 @@ class MyTransform(ThermoTransform):  # or RandomThermoTransform for stochastic
     def forward(self, container: DataContainer) -> DataContainer:
         tdata = container.get_dataset("/Data/Tdata")
 
-        # Validate early
         if tdata.ndim != 3:
-            raise ValueError(f"Expected 3D tensor (H×W×T), got {tdata.shape}")
+            raise ValueError(f"Expected 3D tensor (H x W x T), got {tdata.shape}.")
 
-        # Process (use tensor ops, not loops)
         processed = self._process(tdata)
-
         container.update_dataset("/Data/Tdata", processed)
         return container
-
-    def extra_repr(self) -> str:
-        return f"param={self.param}"
 ```
 
-## Code Conventions
+Keep `forward()` easy to scan. If a transform contains dense math, isolate that math in private helpers and keep the main path linear.
 
-**Ruff** (line length: 120, Google docstrings, double quotes):
-```python
-def method(self, param: int, optional: str | None = None) -> DataContainer:
-    """Short summary ending with period.
+### Dataset Pattern
 
-    Args:
-        param (int): Description.
-        optional (str, optional): Description. Defaults to None.
+`BaseDataset` is the reference for dataset code:
 
-    Returns:
-        DataContainer: Description.
+- keep `__getitem__()` direct and explicit
+- validate indices before any load
+- keep cache behavior readable and local
+- use private state only where it clearly simplifies the public API
 
-    Raises:
-        ValueError: When param is invalid.
-    """
-```
-
-**Type Hints** (modern Python 3.10+):
-```python
-def process(data: list[int]) -> dict[str, float] | None:  # Not List, Optional
-    pass
-```
-
-**Naming**:
-- Classes: `PascalCase`
-- Functions/methods: `snake_case`
-- Private: `__double_underscore`
-
-**Errors** (descriptive with context):
-```python
-raise ValueError(f"Frame {idx} out of range [0, {total_frames})")
-```
-
-## Testing
-
-**Test organization**:
-- Tests organized by domain: `tests/{data,dataset,io,integration}/test_*.py`
-- Use fixtures from `tests/conftest.py`
-
-**Pattern**:
-```python
-@pytest.mark.parametrize("num_frames,expected", [(10, (96,96,10)), (32, (96,96,32))])
-def test_feature(sample_container, num_frames, expected):
-    # Test implementation
-    assert result.shape == expected
-```
-
-**Common commands**:
-```bash
-pytest tests/                    # All tests
-pytest -k "test_name"           # Pattern match
-pytest --benchmark-skip         # Skip benchmarks (faster)
-ruff check --fix .              # Lint and fix
-mypy src/pythermondt            # Type check
-pre-commit run --all-files      # All quality checks
-```
-
-## Critical Details
+## Critical Domain Rules
 
 ### Temporal Consistency
-When selecting frames, **always update temporal metadata together**:
-```python
-# Select frames
-new_tdata = tdata[..., indices]
-new_domain_values = domain_values[indices] - domain_values[indices[0]]  # Zero-base!
 
-# Update together
+Whenever frames are selected, resampled, or reordered, update the temporal metadata together:
+
+```python
 container.update_datasets(
     ("/Data/Tdata", new_tdata),
-    ("/MetaData/DomainValues", new_domain_values)
+    ("/MetaData/DomainValues", new_domain_values),
+    ("/MetaData/ExcitationSignal", new_excitation_signal),
 )
 ```
 
+If the new sequence starts at a later time, zero-base `DomainValues` when that is the established behavior of the transform.
+
 ### Unit Management
+
+Update units when a transform changes physical meaning:
+
 ```python
 from pythermondt.data.units import Units
 
-# Update units when transformation changes physical meaning
-container.set_unit("/Data/Tdata", Units.KELVIN)  # After ApplyLUT: arbitrary→kelvin
+container.set_unit("/Data/Tdata", Units.KELVIN)
 ```
 
 ### Performance
-- Use tensor operations over loops: `processed = tdata * scale` not `for i in range(...)`
-- Validate dimensions early: `if tdata.ndim != 3: raise ValueError(...)`
-- Leverage `settings.num_workers` for parallelism
+
+- Prefer tensor operations over Python loops.
+- Flatten only when it clearly simplifies vectorized computation.
+- Keep memory behavior understandable; do not hide expensive copies.
+- Use `settings.num_workers` when worker count should follow project configuration.
+
+## Testing
+
+- All functional changes must include tests.
+- Mirror the source layout under `tests/`.
+- Use fixtures from `tests/conftest.py`.
+- Prefer parametrized tests for shape, bounds, and mode coverage.
+- For bug fixes, add or update a test that fails before the fix and passes after it.
+
+Common locations:
+
+- `tests/data/`
+- `tests/dataset/`
+- `tests/io/`
+- `tests/integration/`
+
+## Validation Commands
+
+```bash
+pytest tests/
+pytest -k "test_name"
+pytest --benchmark-skip
+ruff check --fix .
+ruff format .
+mypy src/pythermondt
+pre-commit run --all-files
+```
+
+Run the smallest relevant test set during development, then run the broader checks appropriate for the change.
 
 ## Key Locations
 
-**Transforms**: `src/pythermondt/transforms/{base,preprocessing,sampling,normalization,augmentation}.py`
-**Readers**: `src/pythermondt/readers/{local_reader,s3_reader}.py`
-**Tests**: `tests/conftest.py` (fixtures), `tests/{data,dataset,io,integration}/test_*.py`
-**Config**: `pyproject.toml`, `src/pythermondt/config.py`
-
-## Development Workflow
-
-```bash
-# Setup
-uv venv && uv pip install -e . && uv pip install -r requirements_dev.txt && pre-commit install
-
-# Quality checks (run before commit)
-ruff check --fix . && ruff format . && mypy src/pythermondt && pytest tests/
-```
+- Transforms: `src/pythermondt/transforms/{base,preprocessing,sampling,normalization,augmentation}.py`
+- Datasets: `src/pythermondt/dataset/`
+- Readers: `src/pythermondt/readers/{local_reader,s3_reader}.py`
+- Tests: `tests/conftest.py`, `tests/{data,dataset,io,integration}/`
+- Config: `pyproject.toml`, `src/pythermondt/config.py`
 
 ## Essential Rules
 
-1. Never mix functionality and whitespace changes
-2. All functionality changes must include tests
-3. Run pre-commit hooks before committing
-4. Validate tensor dimensions early with clear errors
-5. Maintain temporal consistency (Tdata, DomainValues, ExcitationSignal)
-6. Update units when physical meaning changes
-7. Use tensor operations over loops
-8. Follow PyTorch Module patterns (inherit from ThermoTransform/RandomThermoTransform)
+1. Match the coding style of `NonUniformSampling` and `BaseDataset`.
+2. Prefer direct, linear implementations over extra abstraction.
+3. Validate early and fail with clear, contextual errors.
+4. Maintain temporal consistency across `Tdata`, `DomainValues`, and `ExcitationSignal`.
+5. Update units when physical meaning changes.
+6. Use tensor operations over loops when possible.
+7. Include tests for every functional change.
+8. Do not mix functionality and whitespace-only cleanup.
 
-Your contributions should feel native to the codebase. Follow patterns, maintain consistency, prioritize clarity and correctness.
-
-Welcome aboard!
+Contributions should feel native to the codebase: compact, readable, explicit, and scientifically correct.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,197 +1,71 @@
 # Claude Code Instructions for PyThermoNDT
 
-## Foundation
+Read `AGENTS.md` first. It defines the project architecture, domain rules, and the preferred coding style.
 
-**Read [AGENTS.md](AGENTS.md) first** - it contains project architecture, conventions, and patterns.
+Keep this file intentionally concise.
 
-This file provides Claude-specific tool usage and workflow guidance.
+- Include only non-obvious, high-value guidance.
+- Prefer concrete rules over repository overviews.
+- Do not duplicate documentation that is easy to discover elsewhere in the repo.
 
-## Tool Usage
+## Canonical Style References
 
-### When to Use Which Tool
+Match these implementations unless the surrounding file clearly uses a different local pattern:
 
-**Explore agent** - Open-ended codebase exploration:
-- "How is RemoveFlash implemented?"
-- "What test fixtures exist?"
-- "Find transforms that modify DomainValues"
+- `src/pythermondt/transforms/sampling.py` - `NonUniformSampling`
+- `src/pythermondt/dataset/base_dataset.py` - `BaseDataset`
 
-**Read tool** - Known specific files:
-```
-Read: src/pythermondt/transforms/sampling.py
-Read: tests/conftest.py
-```
+Target that style on the first try:
 
-**Glob tool** - Pattern matching:
-```
-Glob: src/pythermondt/transforms/*.py
-Glob: tests/**/test_*.py
-```
+- minimal and direct
+- readable top-to-bottom
+- helpful docstrings, not verbose docstrings
+- sparse comments that explain intent, not mechanics
+- early validation with descriptive errors
 
-**Grep tool** - Content search:
-```
-Grep: "class.*Transform" in src/pythermondt/transforms/
-Grep: "@pytest.fixture" in tests/
-```
+## Working Rules
 
-### Before Any Edit
+### Before Editing
 
-**CRITICAL**: Always read files before editing them.
+- Read the file you will edit.
+- Read at least one nearby reference implementation when style or structure matters.
+- Prefer the smallest correct change.
 
-```
-❌ BAD:  User: "Fix sampling.py" → Edit tool immediately
-✅ GOOD: User: "Fix sampling.py" → Read sampling.py → Understand → Edit
-```
+### Tool Use
 
-### Parallel vs Sequential
+- Use `Read` for known files.
+- Use `Glob` for filename discovery.
+- Use `Grep` for content search.
+- Parallelize independent reads and searches.
+- Use `Explore` only for open-ended codebase questions.
 
-**Parallel** (independent operations):
-```python
-# ✅ Read multiple files at once
-Read(file1) + Read(file2) + Read(file3)
+### Editing Style
 
-# ✅ Run independent checks
-Bash(pytest) + Bash(ruff check) + Bash(mypy)
-```
+- Keep methods linear: load -> validate -> compute -> update -> return.
+- Extract helpers only for reused logic, dense math, or real domain concepts.
+- Keep names concrete and domain-specific.
+- Do not add abstraction just to look organized.
 
-**Sequential** (dependent operations):
-```python
-# ✅ Edit before testing the edit
-Edit(file.py) → Bash(pytest tests/)
-```
+### Verification
 
-## Common Workflows
-
-### Adding a Transform
-
-1. **Explore**: `Task(Explore, "Find similar transforms like UniformSampling")`
-2. **Read**: Base class + similar transform
-3. **Implement**: Follow pattern from AGENTS.md
-4. **Verify**: `pytest tests/ && ruff check --fix .`
-
-### Fixing a Bug
-
-1. **Read**: Affected file + test file
-2. **Test first**: Add failing test that reproduces bug
-3. **Fix**: Minimal change to fix issue
-4. **Verify**: Test passes, all tests pass, ruff passes
-
-### Debugging Test Failures
+For functional changes, run the smallest relevant checks first, then broader validation as needed:
 
 ```bash
-# Run specific test with verbose output
-pytest tests/path/test_file.py::test_name -vv
-
-# Common issues:
-# - Tensor shape mismatches (check H×W×T dimensions)
-# - Missing DataContainer paths
-# - Temporal inconsistency (Tdata vs DomainValues)
-# - Unit mismatches after transforms
+pytest tests/
+pytest -k "test_name"
+pytest --benchmark-skip
+ruff check --fix .
+ruff format .
+mypy src/pythermondt
+pre-commit run --all-files
 ```
 
-## Quick Command Reference
+## Common Pitfalls
 
-```bash
-# Testing
-pytest tests/                          # All tests
-pytest -k "test_name"                 # Pattern match
-pytest --benchmark-skip               # Skip benchmarks
-pytest -x                             # Stop on first failure
+- Frame operations must keep `Tdata`, `DomainValues`, and `ExcitationSignal` in sync.
+- Temporal transforms should preserve or intentionally reset the domain origin.
+- Update units when a transform changes physical meaning.
+- Prefer tensor operations over loops.
+- All functionality changes require tests.
 
-# Quality
-ruff check --fix . && ruff format .   # Lint and format
-mypy src/pythermondt                  # Type check
-pre-commit run --all-files            # All hooks
-
-# Development
-uv venv && uv pip install -e . && uv pip install -r requirements_dev.txt && pre-commit install
-```
-
-## Critical Patterns
-
-### Temporal Consistency (Most Common Mistake)
-
-**Always update Tdata and DomainValues together**:
-```python
-# ✅ CORRECT
-new_tdata = tdata[..., indices]
-new_domain = domain[indices] - domain[indices[0]]  # Zero-base!
-container.update_datasets(
-    ("/Data/Tdata", new_tdata),
-    ("/MetaData/DomainValues", new_domain)
-)
-
-# ❌ WRONG - Only updating Tdata
-container.update_dataset("/Data/Tdata", tdata[..., indices])
-```
-
-### Validate Early
-
-```python
-# ✅ At the start of forward()
-if tdata.ndim != 3:
-    raise ValueError(f"Expected 3D (H×W×T), got {tdata.shape}")
-```
-
-### Unit Updates
-
-```python
-# When transform changes physical meaning (e.g., ApplyLUT)
-from pythermondt.data.units import Units
-container.set_unit("/Data/Tdata", Units.KELVIN)
-```
-
-## Key File Locations
-
-```
-src/pythermondt/
-├── transforms/
-│   ├── base.py                # Base classes
-│   ├── preprocessing.py       # ApplyLUT, RemoveFlash, CropFrames
-│   ├── sampling.py            # Frame sampling
-│   ├── normalization.py       # MinMax, Z-score
-│   └── augmentation.py        # Data augmentation
-├── readers/
-│   ├── local_reader.py
-│   └── s3_reader.py
-├── data/datacontainer/
-│   └── datacontainer.py       # Core container
-└── config.py
-
-tests/
-├── conftest.py                # Global fixtures
-├── integration/               # Integration tests
-├── data/                      # Data module tests
-├── dataset/                   # Dataset tests
-└── io/                        # I/O tests (backends, parsers)
-```
-
-## When to Use EnterPlanMode
-
-**Use for**:
-- New features (transforms, readers)
-- Multi-file changes
-- Architectural changes
-- Multiple valid approaches
-
-**Skip for**:
-- Typos, single-line fixes
-- Simple test additions
-- Obvious bug fixes
-
-## Common Fixtures (from tests/conftest.py)
-
-- `sample_tensor` - 3D tensor (96×96×100)
-- `sample_container` - DataContainer with test data
-- `localreader_with_file` - LocalReader with test file
-- `sample_transform` - Example transform instance
-
-## Essential Reminders
-
-1. **Read before editing** - Never propose changes to unread code
-2. **Maintain temporal consistency** - Update Tdata + DomainValues together
-3. **Validate early** - Check shapes/dimensions at start of methods
-4. **Test thoroughly** - Mirror structure, use parametrize
-5. **Follow conventions** - Ruff (120 chars), Google docstrings, type hints
-6. **Never mix** - Functionality and whitespace in same commit
-
-See [AGENTS.md](AGENTS.md) for detailed architecture, patterns, and examples.
+If `AGENTS.md` and local file style disagree, follow the local file style unless it conflicts with an explicit project rule.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ quote-style = "double"
 [tool.pylint.messages_control]
 # Config general
 source-roots = ["src"]
-fail-on = "I" # Fail on informatioal messages aswell ==> to catch useless suppressions
+fail-on = "I" # Fail on informational messages as well ==> to catch useless suppressions
 py-version = "3.10" # Set Python version to 3.10
 
 # Configure messages
@@ -168,7 +168,7 @@ disable = [
     "missing-class-docstring",      # C0115
     "missing-function-docstring",   # C0116
     "fixme", # W0511
-    "line-too-long", # C0301 ==> this is handled by ruff aswell
+    "line-too-long", # C0301 ==> this is handled by ruff as well
 ]
 
 [tool.pylint.design]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,5 +227,4 @@ skip_dependencies = [
     "azure-identity", # Buggy with complex license
     "azure-core", # Buggy with complex license
     "torch", # Buggy with complex license
-    "matplotlib-inline" # TODO: Remove once https://github.com/ipython/matplotlib-inline/pull/58 is merged
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,7 @@ dependencies = [
     # Azure
     "azure-storage-blob>=12.20",
     "azure-identity>=1.20",
-    # TODO: Update when wheels are available for newer Python versions
-    "azure-identity-broker>=1.1.0; sys_platform == 'win32' and python_version < '3.14'",
+    "azure-identity-broker>=1.1.0; sys_platform == 'win32'",
 ]
 
 [dependency-groups]

--- a/src/pythermondt/io/parsers/edevis_parser.py
+++ b/src/pythermondt/io/parsers/edevis_parser.py
@@ -176,7 +176,7 @@ class EdevisParser(BaseParser):
                             buffer = bytearray(data_bytes.read(lut_size * 4))  # 4 bytes per LUT entry assuming float32
                             lut_data = torch.frombuffer(buffer, dtype=torch.float32)
 
-                            # Convert LUT data to Kelvin because Thermocontainer stores LUT in Kelvin
+                            # Convert LUT data to Kelvin because ThermoContainer stores LUT in Kelvin
                             container.update_dataset("/MetaData/LookUpTable", lut_data + 273.15)
 
                     # Define supported bit depths for each data type

--- a/src/pythermondt/io/parsers/simulation_parser.py
+++ b/src/pythermondt/io/parsers/simulation_parser.py
@@ -17,7 +17,7 @@ class SimulationParser(BaseParser):
     def parse(data: IOPathWrapper) -> DataContainer:  # pylint: disable=too-many-branches
         """Parses the data from the given IOPathWrapper object into a DataContainer object.
 
-        The IOPathWrapper object must contain a .mat file with simulattion data from COMSOL.
+        The IOPathWrapper object must contain a .mat file with simulation data from COMSOL.
 
         Args:
             data (IOPathWrapper): IOPathWrapper object containing the data to be parsed.
@@ -38,7 +38,7 @@ class SimulationParser(BaseParser):
         except MatReadError as o:
             raise ValueError("The given IOPathWrapper object does not contain a valid .mat file.") from o
 
-        # Create an empty Thermocontainer ==> predefined structure
+        # Create an empty ThermoContainer ==> predefined structure
         datacontainer = ThermoContainer()
 
         # Add source as an attribute

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -46,8 +46,8 @@ class ApplyLUT(ThermoTransform):
         if tdata.dtype != torch.uint16 and tdata.negative().any():
             raise ValueError("Invalid values in Tdata. Applying LookUpTable is not supported.")
 
-        # Except invalid indices. Negative indices are not allowed because indexing in negative values in tdata creates
-        # ambiguous results when applying the LUT. However if Tdata is unsigned this will not be a problem.
+        # Catch invalid indices. Negative indices are not allowed because negative values in Tdata create
+        # ambiguous results when applying the LUT. If Tdata is unsigned this will not be a problem.
         try:
             tdata = torch.take(lut, tdata.flatten().long()).reshape(tdata.shape)
         except IndexError as e:

--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -60,7 +60,7 @@ class SelectFrameRange(ThermoTransform):
 
         Args:
             start (int, optional): Start index of the frame range. Default is None, which means the start index is 0.
-            end (int, optional): End index of the frame range, which is inclusiv.
+            end (int, optional): End index of the frame range, which is inclusive.
                 Default is None, which means the end index is the last frame.
         """
         super().__init__()
@@ -164,7 +164,7 @@ class NonUniformSampling(ThermoTransform):
             float: The minimum tau value that satisfies the constraint.
         """
         low = dt_min  # use dt_min as lower bound
-        high = t_end  # use t_end as a upper bond because tau >= t_end makes no sense
+        high = t_end  # use t_end as an upper bound because tau >= t_end makes no sense
 
         # 1.) Binary search
         while high - low > self.precision:

--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -63,7 +63,7 @@ class CallbackTransform(_BaseTransform):
             callback (Callable[[DataContainer], _BaseTransform]): A function that takes a DataContainer and returns a
                 transform instance. This function will be called each time the transform is applied.
             is_random (bool | None, optional): Whether the transform is random. If None, randomness is inferred from
-                the callback function, with fall to deterministic if inference fails. Defaults to None.
+                the callback function, falling back to deterministic if inference fails. Defaults to None.
         """
         super().__init__()
         self.callback = callback

--- a/tests/data/datacontainer/test_base.py
+++ b/tests/data/datacontainer/test_base.py
@@ -6,7 +6,6 @@ import torch
 from pythermondt.data import DataContainer
 from pythermondt.data.datacontainer.base import DataContainerBase
 from pythermondt.data.datacontainer.node import DataNode, GroupNode, RootNode
-from pythermondt.data.datacontainer.utils import split_path
 
 
 def test_path_exists(filled_container: DataContainer):
@@ -55,8 +54,6 @@ def test_is_groupnode(filled_container: DataContainer):
 
 def test_is_rootnode(filled_container: DataContainer):
     # Test the root path
-    print(split_path("/"))
-    print(filled_container.nodes.keys())
     assert filled_container._is_rootnode("/") is True
 
     # Test non-root paths

--- a/tests/dataset/test_thermo_dataset.py
+++ b/tests/dataset/test_thermo_dataset.py
@@ -63,9 +63,6 @@ def test_duplicate_files(caplog, paths: tuple[str, str]):
     localreader1 = LocalReader(pattern=paths[0])
     localreader2 = LocalReader(pattern=paths[1])
 
-    print(f"Files in localreader1: {localreader1.files}")
-    print(f"Files in localreader2: {localreader2.files}")
-
     with pytest.warns(UserWarning, match="Duplicate files found for reader of type LocalReader"):
         ThermoDataset([localreader1, localreader2])
 
@@ -85,9 +82,6 @@ def test_no_false_positive_duplicates(paths: tuple[str, str]):
     """Test that duplicate detection doesn't produce false positives for non-overlapping sources."""
     localreader1 = LocalReader(pattern=paths[0])
     localreader2 = LocalReader(pattern=paths[1])
-
-    print(f"Files in localreader1: {localreader1.files}")
-    print(f"Files in localreader2: {localreader2.files}")
 
     # This should NOT raise an exception
     try:


### PR DESCRIPTION
- Fix typos and grammar across source files and documentation (simulattion → simulation, inclusiv → inclusive, upper bond → upper bound, Except → Catch, aswell → as well, fall to → falling back to, Thermocontainer → ThermoContainer).
- Remove debug print() statements from tests (test_base.py, test_thermo_dataset.py) and an unused import (split_path).
- Resolve matplotlib-inline todo: remove skip entry from pyproject.toml now that the upstream PR is merged.
- Update azure-identity-broker dependency to remove the python_version < '3.14' constraint (msal now supports Python 3.14).
- Consolidate and deduplicate AI agent instructions: .github/copilot-instructions.md now points to AGENTS.md as the single source of truth, reducing it from 133 lines to 42. AGENTS.md and CLAUDE.md are also cleaned up.