### PR TITLE
Add interactive ground truth overlay with configurable color and opacity

### DIFF
--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -140,6 +140,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self._slider_cid = self.frame_slider.on_changed(self.update_frame)
             self._clear_btn_cid = self.clear_button.on_clicked(self.clear_points)
             self._annotation_cid = self.annotation_toggle.on_clicked(self.toggle_annotation)
+            self._gt_cid: int | None = None
             if self._has_defects:
                 self._gt_cid = self.groundtruth_toggle.on_clicked(self.toggle_groundtruth)
             self._canvas_connection_ids = [
@@ -169,7 +170,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self.frame_slider.disconnect(self._slider_cid)
             self.clear_button.disconnect(self._clear_btn_cid)
             self.annotation_toggle.disconnect(self._annotation_cid)
-            if hasattr(self, "_gt_cid"):
+            if self._gt_cid is not None:
                 self.groundtruth_toggle.disconnect(self._gt_cid)
 
             self.container.release_interactive_analyzer(self)

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -4,6 +4,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import ticker
 from matplotlib.colors import to_rgba
+from matplotlib.contour import QuadContourSet
+from matplotlib.image import AxesImage
 from matplotlib.lines import Line2D
 from matplotlib.offsetbox import AnnotationBbox, TextArea
 from matplotlib.widgets import Button, CheckButtons, Slider
@@ -24,13 +26,20 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
     # TODO: Refactor visualization logic to reduce the tight coupling between data handling and visualization.
     class InteractiveAnalyzer:  # pylint: disable=too-many-instance-attributes
-        def __init__(self, parent: "VisualizationOps"):
+        def __init__(self, parent: "VisualizationOps", overlay_color: OverlayColorOption = "red"):
             """Initialize the interactive analyzer for thermographic data visualization.
 
             Args:
                 parent (VisualizationOps): The parent container for the interactive analysis.
+                overlay_color: Color for the ground truth overlay. One of "red", "green", "blue".
+                    Defaults to "red".
             """
-            # 1.) Retrieve data from the container
+            # 1.) Validate and store overlay configuration
+            if overlay_color not in {"red", "green", "blue"}:
+                raise ValueError(f"Invalid overlay_color '{overlay_color}'. Must be one of: red, green, blue")
+            self._overlay_color = overlay_color
+
+            # 2.) Retrieve data from the container
             self.container = parent
             # Transpose to (frame, y, x) for faster access - this avoids the need to squeeze the data
             self.tdata = parent.get_dataset("/Data/Tdata").numpy(force=True).transpose(2, 0, 1)
@@ -38,11 +47,22 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self.data_unit = parent.get_unit("/Data/Tdata")
             self.domain_unit = parent.get_unit("/MetaData/DomainValues")
 
-            # 2.) Setup the figure, axes and colorbar
-            # Create the main figure with two subplots
-            self.fig = plt.figure(figsize=(15, 6))
-            self.frame_ax = plt.subplot2grid((1, 2), (0, 0))
-            self.profile_ax = plt.subplot2grid((1, 2), (0, 1))
+            # Load ground truth and check for any defect pixels
+            gt_tensor = parent.get_dataset("/GroundTruth/DefectMask")
+            self.groundtruth: np.ndarray | None = None
+            self._has_defects = False
+            if gt_tensor is not None:
+                gt = gt_tensor.numpy(force=True)
+                if (gt > 0).any():
+                    self.groundtruth = gt
+                    self._has_defects = True
+
+            # 3.) Setup the figure, axes and colorbar
+            # Create a dedicated bottom row for controls so widgets never overlap plot labels.
+            self.fig = plt.figure(figsize=(16, 7))
+            gs = self.fig.add_gridspec(2, 16, height_ratios=[24, 1], hspace=0.35, wspace=0.7)
+            self.frame_ax = self.fig.add_subplot(gs[0, :8])
+            self.profile_ax = self.fig.add_subplot(gs[0, 8:])
 
             # Initialize the frame display
             self.current_frame = 0  # type: int
@@ -63,26 +83,35 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             formatter = ticker.ScalarFormatter(useMathText=False, useOffset=False)
             self.colorbar = plt.colorbar(self.frame_img, ax=self.frame_ax, format=formatter)
 
-            # 3.) Setup the interactive elements
+            # 4.) Setup the interactive elements in the dedicated bottom row
             # Setup the slider
-            slider_ax = plt.axes((0.2, 0.02, 0.6, 0.03))
+            slider_ax = self.fig.add_subplot(gs[1, :9])
             self.frame_slider = Slider(
                 ax=slider_ax, label="Frame", valmin=0, valmax=self.tdata.shape[0] - 1, valinit=0, valstep=1
             )
 
             # Setup the clear button
-            clear_ax = plt.axes((0.85, 0.02, 0.1, 0.03))
+            clear_ax = self.fig.add_subplot(gs[1, 10:12])
             self.clear_button = Button(clear_ax, "Clear Points")
 
             # Create checkbox for annotation toggle
-            check_ax = plt.axes((0.85, 0.07, 0.1, 0.03))  # Position below clear button
+            check_ax = self.fig.add_subplot(gs[1, 12:14])
             self.annotation_toggle = CheckButtons(
                 check_ax,
                 ["Show Value"],
                 [True],  # Initially checked
             )
 
-            # 4.) Initialize state variables
+            # Create checkbox for ground truth overlay toggle (only if defects exist)
+            if self._has_defects:
+                check_gt_ax = self.fig.add_subplot(gs[1, 14:])
+                self.groundtruth_toggle = CheckButtons(
+                    check_gt_ax,
+                    ["Show GT"],
+                    [False],  # Initially unchecked
+                )
+
+            # 5.) Initialize state variables
             # Store selected points and their profiles
             self.selected_points: list[tuple[int, int]] = []
             self.point_markers: list[Line2D] = []
@@ -90,6 +119,10 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self.colors = ["red", "blue", "green", "purple"]  # Colors for up to 4 points
             self._last_hover_pixel: tuple[int, int] | None = None
             self._closed = False
+
+            # Ground truth overlay state
+            self._overlay_img: AxesImage | None = None
+            self._overlay_contour: QuadContourSet | None = None
 
             # Initialize annotation box once
             self.cursor_annotation_text = TextArea("", textprops={"color": "white", "backgroundcolor": "black"})
@@ -103,17 +136,19 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self.cursor_annotation_box.set_visible(False)  # Hide initially
             self.frame_ax.add_artist(self.cursor_annotation_box)
 
-            # 5.) Connect events
+            # 6.) Connect events
             self._slider_cid = self.frame_slider.on_changed(self.update_frame)
             self._clear_btn_cid = self.clear_button.on_clicked(self.clear_points)
             self._annotation_cid = self.annotation_toggle.on_clicked(self.toggle_annotation)
+            if self._has_defects:
+                self._gt_cid = self.groundtruth_toggle.on_clicked(self.toggle_groundtruth)
             self._canvas_connection_ids = [
                 self.fig.canvas.mpl_connect("button_press_event", self.on_click),
                 self.fig.canvas.mpl_connect("motion_notify_event", self.on_mouse_move),
                 self.fig.canvas.mpl_connect("close_event", self.on_close),
             ]
 
-            # 6.) Initialize blitting for faster rendering (if possible)
+            # 7.) Initialize blitting for faster rendering (if possible)
             self.fig.canvas.draw_idle()
 
         @property
@@ -134,6 +169,8 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self.frame_slider.disconnect(self._slider_cid)
             self.clear_button.disconnect(self._clear_btn_cid)
             self.annotation_toggle.disconnect(self._annotation_cid)
+            if hasattr(self, "_gt_cid"):
+                self.groundtruth_toggle.disconnect(self._gt_cid)
 
             self.container.release_interactive_analyzer(self)
 
@@ -151,6 +188,40 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                 self.cursor_annotation_box.set_visible(False)
                 self._last_hover_pixel = None
                 self.fig.canvas.draw_idle()
+
+        def toggle_groundtruth(self, event):  # pylint: disable=unused-argument
+            """Toggle ground truth overlay on/off."""
+            if self.groundtruth is None:
+                return
+            if self.groundtruth_toggle.get_status()[0]:
+                # Show overlay: create RGBA mask and contour from ground truth
+                binary_gt = self.groundtruth > 0
+                height, width = binary_gt.shape
+
+                # Build RGBA overlay matching the configured color
+                overlay = np.zeros((height, width, 4))
+                channel_idx = {"red": 0, "green": 1, "blue": 2}[self._overlay_color]
+                overlay[binary_gt, channel_idx] = 1.0
+                overlay[binary_gt, 3] = 0.6  # Alpha
+
+                self._overlay_img = self.frame_ax.imshow(overlay, aspect="auto", interpolation="none")
+
+                # Add contour outline in a darker shade of the overlay color
+                r, g, b, _ = to_rgba(self._overlay_color)
+                contour_color = (r * 0.6, g * 0.6, b * 0.6)
+                self._overlay_contour = self.frame_ax.contour(
+                    binary_gt.astype(float), levels=[0.5], colors=[contour_color], linewidths=1.5
+                )
+            else:
+                # Remove overlay and contour
+                if self._overlay_img is not None:
+                    self._overlay_img.remove()
+                    self._overlay_img = None
+                if self._overlay_contour is not None:
+                    self._overlay_contour.remove()
+                    self._overlay_contour = None
+
+            self.fig.canvas.draw_idle()
 
         def on_mouse_move(self, event):
             """Update annotation when mouse moves over the image."""
@@ -416,9 +487,14 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         if self._interactive_analyzer is analyzer:
             self._interactive_analyzer = None
 
-    def analyse_interactive(self):
-        """Launch interactive analysis session for thermographic data visualization."""
+    def analyse_interactive(self, overlay_color: OverlayColorOption = "red"):
+        """Launch interactive analysis session for thermographic data visualization.
+
+        Args:
+            overlay_color: Color for the ground truth overlay when the "Show GT" toggle is active.
+                Must be one of "red", "green", "blue". Defaults to "red".
+        """
         if self._interactive_analyzer is not None and not self._interactive_analyzer.closed:
             self._interactive_analyzer.close(close_figure=True)
-        self._interactive_analyzer = self.InteractiveAnalyzer(self)
+        self._interactive_analyzer = self.InteractiveAnalyzer(self, overlay_color=overlay_color)
         plt.show()

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -63,7 +63,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             # 1.) Validate and store overlay configuration
             if overlay_color not in {"red", "green", "blue"}:
                 raise ValueError(f"Invalid overlay_color '{overlay_color}'. Must be one of: red, green, blue")
-            self._overlay_color = overlay_color
+            self._overlay_color: OverlayColorOption = overlay_color
 
             # 2.) Retrieve data from the container
             self.container = parent

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -50,12 +50,10 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             # Load ground truth and check for any defect pixels
             gt_tensor = parent.get_dataset("/GroundTruth/DefectMask")
             self.groundtruth: np.ndarray | None = None
-            self._has_defects = False
             if gt_tensor is not None:
                 gt = gt_tensor.numpy(force=True)
                 if (gt > 0).any():
                     self.groundtruth = gt
-                    self._has_defects = True
 
             # 3.) Setup the figure, axes and colorbar
             # Create a dedicated bottom row for controls so widgets never overlap plot labels.
@@ -103,7 +101,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             )
 
             # Create checkbox for ground truth overlay toggle (only if defects exist)
-            if self._has_defects:
+            if self.groundtruth is not None:
                 check_gt_ax = self.fig.add_subplot(gs[1, 14:])
                 self.groundtruth_toggle = CheckButtons(
                     check_gt_ax,
@@ -141,7 +139,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             self._clear_btn_cid = self.clear_button.on_clicked(self.clear_points)
             self._annotation_cid = self.annotation_toggle.on_clicked(self.toggle_annotation)
             self._gt_cid: int | None = None
-            if self._has_defects:
+            if self.groundtruth is not None:
                 self._gt_cid = self.groundtruth_toggle.on_clicked(self.toggle_groundtruth)
             self._canvas_connection_ids = [
                 self.fig.canvas.mpl_connect("button_press_event", self.on_click),

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -511,12 +511,17 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         if self._interactive_analyzer is analyzer:
             self._interactive_analyzer = None
 
-    def analyse_interactive(self, overlay_color: OverlayColorOption = "red"):
+    def analyse_interactive(self, overlay_color: OverlayColorOption = "red", overlay_alpha: float = 0.6):
         """Launch interactive analysis session for thermographic data visualization.
 
         Args:
             overlay_color: Color for the ground truth overlay when the "Show GT" toggle is active.
                 Must be one of "red", "green", "blue". Defaults to "red".
+            overlay_alpha: Opacity for the ground truth overlay, in the range [0, 1]. Defaults to 0.6.
+
+        Raises:
+            ValueError: If overlay_color is not one of "red", "green", "blue".
+            ValueError: If overlay_alpha is not in the range [0, 1].
         """
         if self._interactive_analyzer is not None and not self._interactive_analyzer.closed:
             self._interactive_analyzer.close(close_figure=True)

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -52,18 +52,32 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
 
     # TODO: Refactor visualization logic to reduce the tight coupling between data handling and visualization.
     class InteractiveAnalyzer:  # pylint: disable=too-many-instance-attributes
-        def __init__(self, parent: "VisualizationOps", overlay_color: OverlayColorOption = "red"):
+        def __init__(
+            self,
+            parent: "VisualizationOps",
+            overlay_color: OverlayColorOption = "red",
+            overlay_alpha: float = 0.6,
+        ):
             """Initialize the interactive analyzer for thermographic data visualization.
 
             Args:
                 parent (VisualizationOps): The parent container for the interactive analysis.
                 overlay_color: Color for the ground truth overlay. One of "red", "green", "blue".
                     Defaults to "red".
+                overlay_alpha: Opacity for the ground truth overlay, in the range [0, 1].
+                    Defaults to 0.6.
+
+            Raises:
+                ValueError: If overlay_color is not one of "red", "green", "blue".
+                ValueError: If overlay_alpha is not in the range [0, 1].
             """
             # 1.) Validate and store overlay configuration
             if overlay_color not in {"red", "green", "blue"}:
                 raise ValueError(f"Invalid overlay_color '{overlay_color}'. Must be one of: red, green, blue")
+            if not 0 <= overlay_alpha <= 1:
+                raise ValueError(f"Overlay alpha must be in the range [0, 1], got {overlay_alpha}")
             self._overlay_color: OverlayColorOption = overlay_color
+            self._overlay_alpha: float = overlay_alpha
 
             # 2.) Retrieve data from the container
             self.container = parent
@@ -221,7 +235,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             if self.groundtruth_toggle.get_status()[0]:
                 # Show overlay: create RGBA mask and contour from ground truth based on requested color
                 binary_gt = self.groundtruth > 0
-                overlay = _create_overlay_rgba(binary_gt, self._overlay_color)
+                overlay = _create_overlay_rgba(binary_gt, self._overlay_color, self._overlay_alpha)
                 self._overlay_img = self.frame_ax.imshow(overlay, aspect="auto", interpolation="none")
 
                 # Add contour outline in a darker shade of the overlay color

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -51,7 +51,7 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
     _interactive_analyzer: "VisualizationOps.InteractiveAnalyzer | None" = None
 
     # TODO: Refactor visualization logic to reduce the tight coupling between data handling and visualization.
-    class InteractiveAnalyzer:  # pylint: disable=too-many-instance-attributes
+    class InteractiveAnalyzer:  # pylint: disable=too-many-instance-attributes, too-many-statements
         def __init__(
             self,
             parent: "VisualizationOps",
@@ -525,5 +525,5 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
         """
         if self._interactive_analyzer is not None and not self._interactive_analyzer.closed:
             self._interactive_analyzer.close(close_figure=True)
-        self._interactive_analyzer = self.InteractiveAnalyzer(self, overlay_color=overlay_color)
+        self._interactive_analyzer = self.InteractiveAnalyzer(self, overlay_color, overlay_alpha)
         plt.show()

--- a/src/pythermondt/data/datacontainer/visualization_ops.py
+++ b/src/pythermondt/data/datacontainer/visualization_ops.py
@@ -21,6 +21,32 @@ FrameOption: TypeAlias = Literal["ShowGroundTruth", "OverlayGroundTruth", ""]
 OverlayColorOption: TypeAlias = Literal["red", "green", "blue"]
 
 
+def _create_overlay_rgba(
+    binary_mask: np.ndarray,
+    color: OverlayColorOption,
+    alpha: float = 0.6,
+) -> np.ndarray:
+    """Build an RGBA overlay array for a ground truth binary mask.
+
+    Args:
+        binary_mask: Boolean array (H x W) where True marks defect pixels.
+        color: One of "red", "green", "blue".
+        alpha: Overlay opacity in the range [0, 1]. Defaults to 0.6.
+
+    Returns:
+        RGBA array (H x W x 4) with the configured color channel set to 1.0
+        on defect pixels and the alpha channel set to *alpha*.
+    """
+    height, width = binary_mask.shape
+    channel_idx = {"red": 0, "green": 1, "blue": 2}[color]
+
+    overlay = np.zeros((height, width, 4))
+    overlay[binary_mask, channel_idx] = 1.0
+    overlay[binary_mask, 3] = alpha
+
+    return overlay
+
+
 class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
     _interactive_analyzer: "VisualizationOps.InteractiveAnalyzer | None" = None
 
@@ -193,16 +219,9 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
             if self.groundtruth is None:
                 return
             if self.groundtruth_toggle.get_status()[0]:
-                # Show overlay: create RGBA mask and contour from ground truth
+                # Show overlay: create RGBA mask and contour from ground truth based on requested color
                 binary_gt = self.groundtruth > 0
-                height, width = binary_gt.shape
-
-                # Build RGBA overlay matching the configured color
-                overlay = np.zeros((height, width, 4))
-                channel_idx = {"red": 0, "green": 1, "blue": 2}[self._overlay_color]
-                overlay[binary_gt, channel_idx] = 1.0
-                overlay[binary_gt, 3] = 0.6  # Alpha
-
+                overlay = _create_overlay_rgba(binary_gt, self._overlay_color)
                 self._overlay_img = self.frame_ax.imshow(overlay, aspect="auto", interpolation="none")
 
                 # Add contour outline in a darker shade of the overlay color
@@ -411,16 +430,8 @@ class VisualizationOps(GroupOps, DatasetOps, AttributeOps):
                     gt: np.ndarray = groundtruth.numpy(force=True)
                     binary_gt: np.ndarray = gt > 0
 
-                    # Create RGBA overlay with configurable color and alpha
-                    rows, cols = binary_gt.shape
-                    overlay = np.zeros((rows, cols, 4))  # RGBA
-                    if overlay_color == "red":
-                        overlay[binary_gt, 0] = 1.0  # Red channel
-                    elif overlay_color == "green":
-                        overlay[binary_gt, 1] = 1.0  # Green channel
-                    elif overlay_color == "blue":
-                        overlay[binary_gt, 2] = 1.0  # Blue channel
-                    overlay[binary_gt, 3] = overlay_alpha  # Alpha channel
+                    # Create RGBA overlay with specified color and alpha
+                    overlay = _create_overlay_rgba(binary_gt, overlay_color, overlay_alpha)
 
                     frame_ax.imshow(overlay, aspect="auto", interpolation="none")
 

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -34,7 +34,21 @@ def _setup_matplotlib(monkeypatch):
 @pytest.fixture(scope="function")
 def interactive_analyzer(thermo_container: ThermoContainer) -> VisualizationOps.InteractiveAnalyzer:
     """Create an InteractiveAnalyzer instance from the test ThermoContainer."""
-    return VisualizationOps.InteractiveAnalyzer(thermo_container)
+    analyzer = VisualizationOps.InteractiveAnalyzer(thermo_container)
+    yield analyzer
+    analyzer.close(close_figure=True)
+
+
+@pytest.fixture(scope="function")
+def no_defect_analyzer() -> VisualizationOps.InteractiveAnalyzer:
+    """InteractiveAnalyzer backed by a container with no defect pixels."""
+    container = ThermoContainer()
+    container.update_dataset("/Data/Tdata", np.zeros((5, 5, 3)))
+    container.update_dataset("/MetaData/DomainValues", np.arange(3, dtype=np.float64))
+    # DefectMask is empty → groundtruth remains None
+    analyzer = VisualizationOps.InteractiveAnalyzer(container)
+    yield analyzer
+    analyzer.close(close_figure=True)
 
 
 def test_frame_number_negative(thermo_container: ThermoContainer):
@@ -356,19 +370,6 @@ def test_interactive_toggle_annotation_off(interactive_analyzer: VisualizationOp
 
     assert not interactive_analyzer.cursor_annotation_box.get_visible()
     assert interactive_analyzer._last_hover_pixel is None
-
-
-# ── No-defect ground truth edge case ────────────────────────────────────────
-
-
-@pytest.fixture(scope="function")
-def no_defect_analyzer() -> VisualizationOps.InteractiveAnalyzer:
-    """InteractiveAnalyzer backed by a container with no defect pixels."""
-    container = ThermoContainer()
-    container.update_dataset("/Data/Tdata", np.zeros((5, 5, 3)))
-    container.update_dataset("/MetaData/DomainValues", np.arange(3, dtype=np.float64))
-    # DefectMask is empty → groundtruth remains None
-    return VisualizationOps.InteractiveAnalyzer(container)
 
 
 def test_interactive_no_defect_skips_toggle(no_defect_analyzer: VisualizationOps.InteractiveAnalyzer):

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -32,7 +34,7 @@ def _setup_matplotlib(monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def interactive_analyzer(thermo_container: ThermoContainer) -> VisualizationOps.InteractiveAnalyzer:
+def interactive_analyzer(thermo_container: ThermoContainer) -> Generator[VisualizationOps.InteractiveAnalyzer]:
     """Create an InteractiveAnalyzer instance from the test ThermoContainer."""
     analyzer = VisualizationOps.InteractiveAnalyzer(thermo_container)
     yield analyzer
@@ -40,7 +42,7 @@ def interactive_analyzer(thermo_container: ThermoContainer) -> VisualizationOps.
 
 
 @pytest.fixture(scope="function")
-def no_defect_analyzer() -> VisualizationOps.InteractiveAnalyzer:
+def no_defect_analyzer() -> Generator[VisualizationOps.InteractiveAnalyzer]:
     """InteractiveAnalyzer backed by a container with no defect pixels."""
     container = ThermoContainer()
     container.update_dataset("/Data/Tdata", np.zeros((5, 5, 3)))

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -300,3 +300,99 @@ def test_interactive_invalid_overlay_color_raises(thermo_container: ThermoContai
     """Invalid overlay_color passed to InteractiveAnalyzer raises ValueError."""
     with pytest.raises(ValueError, match=r"Invalid overlay_color"):
         VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color="purple")  # type: ignore
+
+
+def test_interactive_close_double_call_no_error(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """Closing an already-closed analyzer is a no-op."""
+    interactive_analyzer.close(close_figure=False)
+    interactive_analyzer.close(close_figure=False)  # Should not raise
+
+
+def test_interactive_closed_property_after_close(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """Closed returns True after close()."""
+    assert not interactive_analyzer.closed
+    interactive_analyzer.close(close_figure=False)
+    assert interactive_analyzer.closed
+
+
+def test_interactive_update_frame_noop(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """update_frame with the current frame value is a no-op."""
+    current = interactive_analyzer.current_frame
+    interactive_analyzer.update_frame(float(current))
+    assert interactive_analyzer.current_frame == current
+
+
+def test_interactive_clear_points(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """clear_points removes all selected points, markers, and profile lines."""
+    # Manually simulate a click by adding state directly
+    interactive_analyzer.selected_points.append((10, 10))
+    marker = interactive_analyzer.frame_ax.plot(10, 10, "x", color="red", markersize=10)[0]
+    interactive_analyzer.point_markers.append(marker)
+    line = interactive_analyzer.profile_ax.plot([0, 1], [0, 1], color="red")[0]
+    interactive_analyzer.profile_lines.append(line)
+
+    interactive_analyzer.clear_points(None)
+
+    assert interactive_analyzer.selected_points == []
+    assert interactive_analyzer.point_markers == []
+    assert interactive_analyzer.profile_lines == []
+    assert marker not in interactive_analyzer.frame_ax.lines
+    assert line not in interactive_analyzer.profile_ax.lines
+
+
+def test_interactive_toggle_annotation_off(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """Toggling Show Value off hides the cursor annotation box."""
+    # Show the annotation first so we can verify it gets hidden
+    interactive_analyzer.cursor_annotation_box.set_visible(True)
+    interactive_analyzer._last_hover_pixel = (5, 5)
+
+    # Simulate unchecked checkbox
+    orig_get_status = interactive_analyzer.annotation_toggle.get_status
+    interactive_analyzer.annotation_toggle.get_status = lambda: [False]
+    try:
+        interactive_analyzer.toggle_annotation(None)
+    finally:
+        interactive_analyzer.annotation_toggle.get_status = orig_get_status
+
+    assert not interactive_analyzer.cursor_annotation_box.get_visible()
+    assert interactive_analyzer._last_hover_pixel is None
+
+
+# ── No-defect ground truth edge case ────────────────────────────────────────
+
+
+@pytest.fixture(scope="function")
+def no_defect_analyzer() -> VisualizationOps.InteractiveAnalyzer:
+    """InteractiveAnalyzer backed by a container with no defect pixels."""
+    container = ThermoContainer()
+    container.update_dataset("/Data/Tdata", np.zeros((5, 5, 3)))
+    container.update_dataset("/MetaData/DomainValues", np.arange(3, dtype=np.float64))
+    # DefectMask is empty → _has_defects will be False
+    return VisualizationOps.InteractiveAnalyzer(container)
+
+
+def test_interactive_no_defect_skips_toggle(no_defect_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """When no defect pixels exist, the Show GT checkbox is not created."""
+    assert not no_defect_analyzer._has_defects
+    assert no_defect_analyzer.groundtruth is None
+    assert not hasattr(no_defect_analyzer, "groundtruth_toggle")
+
+
+# ── analyse_interactive public API flow ─────────────────────────────────────
+
+
+def test_analyse_interactive_flow(thermo_container: ThermoContainer):
+    """analyse_interactive creates an analyzer, registers it, and releases on close."""
+    thermo_container.analyse_interactive()
+    analyzer = thermo_container._interactive_analyzer
+    assert analyzer is not None
+    assert not analyzer.closed
+
+    # Close the analyzer — this should trigger release_interactive_analyzer
+    analyzer.close(close_figure=True)
+    assert thermo_container._interactive_analyzer is None
+
+    # Opening a new analyzer after close works
+    thermo_container.analyse_interactive(overlay_color="green")
+    assert thermo_container._interactive_analyzer is not None
+    thermo_container._interactive_analyzer.close(close_figure=True)

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -318,6 +318,21 @@ def test_interactive_invalid_overlay_color_raises(thermo_container: ThermoContai
         VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color="purple")  # type: ignore
 
 
+@pytest.mark.parametrize("alpha", [-0.1, 1.1, -0.5, 1.5])
+def test_interactive_alpha_out_of_range(thermo_container: ThermoContainer, alpha: float):
+    """Invalid overlay_alpha passed to InteractiveAnalyzer raises ValueError."""
+    with pytest.raises(ValueError, match=r"Overlay alpha must be in the range \[0, 1\], got"):
+        VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_alpha=alpha)
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.0, 0.6])
+def test_interactive_alpha_valid(thermo_container: ThermoContainer, alpha: float):
+    """Valid overlay_alpha within [0, 1] is stored and does not raise."""
+    analyzer = VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_alpha=alpha)
+    assert analyzer._overlay_alpha == alpha
+    analyzer.close(close_figure=True)
+
+
 def test_interactive_close_double_call_no_error(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
     """Closing an already-closed analyzer is a no-op."""
     interactive_analyzer.close(close_figure=False)

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -200,6 +200,9 @@ def test_coordinate_valid(thermo_container: ThermoContainer, x, y):
     thermo_container.show_pixel_profile(x, y)
 
 
+# ============================================================================
+# Test InteractiveAnalyzer
+# ============================================================================
 def test_interactive_groundtruth_toggle_on_adds_overlay(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
     """Toggling Show GT on adds an RGBA overlay image and contour to the frame axes."""
     assert interactive_analyzer._has_defects, "Test fixture must have defect pixels"

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -5,6 +5,7 @@ from matplotlib.colors import to_rgba
 from matplotlib.contour import QuadContourSet
 
 from pythermondt.data import ThermoContainer
+from pythermondt.data.datacontainer.visualization_ops import VisualizationOps
 from pythermondt.readers import LocalReader
 
 
@@ -28,6 +29,12 @@ def _setup_matplotlib(monkeypatch):
     import matplotlib.pyplot as plt
 
     plt.close("all")
+
+
+@pytest.fixture(scope="function")
+def interactive_analyzer(thermo_container: ThermoContainer) -> VisualizationOps.InteractiveAnalyzer:
+    """Create an InteractiveAnalyzer instance from the test ThermoContainer."""
+    return VisualizationOps.InteractiveAnalyzer(thermo_container)
 
 
 def test_frame_number_negative(thermo_container: ThermoContainer):
@@ -191,3 +198,100 @@ def test_coordinate_out_of_range(thermo_container: ThermoContainer):
 def test_coordinate_valid(thermo_container: ThermoContainer, x, y):
     """Valid coordinates do not raise."""
     thermo_container.show_pixel_profile(x, y)
+
+
+def test_interactive_groundtruth_toggle_on_adds_overlay(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """Toggling Show GT on adds an RGBA overlay image and contour to the frame axes."""
+    assert interactive_analyzer._has_defects, "Test fixture must have defect pixels"
+    assert interactive_analyzer._overlay_img is None
+    assert interactive_analyzer._overlay_contour is None
+
+    # Simulate toggling the checkbox on through the real CheckButtons callback path
+    interactive_analyzer.groundtruth_toggle.set_active(0)
+
+    # Verify overlay state
+    assert interactive_analyzer._overlay_img is not None, "Overlay image should exist after toggle on"
+    assert interactive_analyzer._overlay_contour is not None, "Contour should exist after toggle on"
+
+    # Verify overlay image is on the axes
+    overlay_imgs = [
+        im
+        for im in interactive_analyzer.frame_ax.get_images()
+        if (arr := im.get_array()) is not None and arr.shape[-1] == 4
+    ]
+    assert len(overlay_imgs) == 1, f"Expected 1 RGBA overlay image on axes, got {len(overlay_imgs)}"
+    overlay_arr = overlay_imgs[0].get_array()
+    assert overlay_arr is not None
+
+    # Verify contour exists on axes
+    contours = [c for c in interactive_analyzer.frame_ax.collections if isinstance(c, QuadContourSet)]
+    assert len(contours) >= 1, "Expected at least 1 contour on frame axes"
+
+
+def test_interactive_groundtruth_toggle_off_removes_overlay(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """Toggling Show GT off removes the overlay image and contour."""
+    # First toggle on
+    interactive_analyzer.groundtruth_toggle.set_active(0)
+    assert interactive_analyzer._overlay_img is not None
+
+    # Then toggle off
+    interactive_analyzer.groundtruth_toggle.set_active(0)
+
+    assert interactive_analyzer._overlay_img is None, "Overlay image should be removed after toggle off"
+    assert interactive_analyzer._overlay_contour is None, "Contour should be removed after toggle off"
+
+
+def test_interactive_groundtruth_persists_across_frames(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
+    """Ground truth overlay persists when navigating to a different frame."""
+    # Toggle overlay on
+    interactive_analyzer.groundtruth_toggle.set_active(0)
+
+    # Collect overlay pixels for verification
+    assert interactive_analyzer._overlay_img is not None
+    overlay_img = interactive_analyzer._overlay_img
+
+    # Navigate to a different frame
+    current_frame = interactive_analyzer.current_frame
+    total_frames = interactive_analyzer.tdata.shape[0]
+    assert total_frames > 1, "Test fixture must have more than one frame"
+    new_frame = (current_frame + 1) % total_frames
+    interactive_analyzer.update_frame(float(new_frame))
+
+    # Verify frame changed
+    assert interactive_analyzer.current_frame == new_frame
+
+    # Verify the overlay is still on the axes (same artist object)
+    assert interactive_analyzer._overlay_img is overlay_img
+    assert overlay_img in interactive_analyzer.frame_ax.get_images()
+
+
+@pytest.mark.parametrize("color, expected_channel", [("red", 0), ("green", 1), ("blue", 2)])
+def test_interactive_overlay_color_configuration(thermo_container: ThermoContainer, color: str, expected_channel: int):
+    """Each overlay color activates the correct RGBA channel in the overlay."""
+    analyzer = VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color=color)
+    assert analyzer._overlay_color == color
+
+    # Toggle on
+    analyzer.groundtruth_toggle.set_active(0)
+
+    overlay_imgs = [
+        im for im in analyzer.frame_ax.get_images() if (arr := im.get_array()) is not None and arr.shape[-1] == 4
+    ]
+    assert len(overlay_imgs) == 1
+    overlay_data = overlay_imgs[0].get_array()
+    assert overlay_data is not None
+
+    # Verify the correct RGBA channel is set to 1.0 on defect pixels
+    gt = thermo_container.get_dataset("/GroundTruth/DefectMask").numpy(force=True)
+    defect_mask = gt > 0
+    if defect_mask.any():
+        channel_values = overlay_data[defect_mask, expected_channel]
+        assert np.allclose(channel_values, 1.0), f"{color} channel not set on defect pixels"
+
+    analyzer.close(close_figure=True)
+
+
+def test_interactive_invalid_overlay_color_raises(thermo_container: ThermoContainer):
+    """Invalid overlay_color passed to InteractiveAnalyzer raises ValueError."""
+    with pytest.raises(ValueError, match=r"Invalid overlay_color"):
+        VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color="purple")

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -205,7 +205,7 @@ def test_coordinate_valid(thermo_container: ThermoContainer, x, y):
 # ============================================================================
 def test_interactive_groundtruth_toggle_on_adds_overlay(interactive_analyzer: VisualizationOps.InteractiveAnalyzer):
     """Toggling Show GT on adds an RGBA overlay image and contour to the frame axes."""
-    assert interactive_analyzer._has_defects, "Test fixture must have defect pixels"
+    assert interactive_analyzer.groundtruth is not None, "Test fixture must have defect pixels"
     assert interactive_analyzer._overlay_img is None
     assert interactive_analyzer._overlay_contour is None
 
@@ -367,13 +367,12 @@ def no_defect_analyzer() -> VisualizationOps.InteractiveAnalyzer:
     container = ThermoContainer()
     container.update_dataset("/Data/Tdata", np.zeros((5, 5, 3)))
     container.update_dataset("/MetaData/DomainValues", np.arange(3, dtype=np.float64))
-    # DefectMask is empty → _has_defects will be False
+    # DefectMask is empty → groundtruth remains None
     return VisualizationOps.InteractiveAnalyzer(container)
 
 
 def test_interactive_no_defect_skips_toggle(no_defect_analyzer: VisualizationOps.InteractiveAnalyzer):
     """When no defect pixels exist, the Show GT checkbox is not created."""
-    assert not no_defect_analyzer._has_defects
     assert no_defect_analyzer.groundtruth is None
     assert not hasattr(no_defect_analyzer, "groundtruth_toggle")
 

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -5,7 +5,7 @@ from matplotlib.colors import to_rgba
 from matplotlib.contour import QuadContourSet
 
 from pythermondt.data import ThermoContainer
-from pythermondt.data.datacontainer.visualization_ops import VisualizationOps
+from pythermondt.data.datacontainer.visualization_ops import OverlayColorOption, VisualizationOps
 from pythermondt.readers import LocalReader
 
 
@@ -266,7 +266,9 @@ def test_interactive_groundtruth_persists_across_frames(interactive_analyzer: Vi
 
 
 @pytest.mark.parametrize("color, expected_channel", [("red", 0), ("green", 1), ("blue", 2)])
-def test_interactive_overlay_color_configuration(thermo_container: ThermoContainer, color: str, expected_channel: int):
+def test_interactive_overlay_color_configuration(
+    thermo_container: ThermoContainer, color: OverlayColorOption, expected_channel: int
+):
     """Each overlay color activates the correct RGBA channel in the overlay."""
     analyzer = VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color=color)
     assert analyzer._overlay_color == color
@@ -294,4 +296,4 @@ def test_interactive_overlay_color_configuration(thermo_container: ThermoContain
 def test_interactive_invalid_overlay_color_raises(thermo_container: ThermoContainer):
     """Invalid overlay_color passed to InteractiveAnalyzer raises ValueError."""
     with pytest.raises(ValueError, match=r"Invalid overlay_color"):
-        VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color="purple")
+        VisualizationOps.InteractiveAnalyzer(thermo_container, overlay_color="purple")  # type: ignore

--- a/tests/data/datacontainer/test_visualization_ops.py
+++ b/tests/data/datacontainer/test_visualization_ops.py
@@ -376,6 +376,9 @@ def test_interactive_no_defect_skips_toggle(no_defect_analyzer: VisualizationOps
     assert no_defect_analyzer.groundtruth is None
     assert not hasattr(no_defect_analyzer, "groundtruth_toggle")
 
+    # The toggle method itself should be a harmless no-op when ground truth is absent
+    no_defect_analyzer.toggle_groundtruth(None)
+
 
 # ── analyse_interactive public API flow ─────────────────────────────────────
 


### PR DESCRIPTION
- Add `overlay_color` and `overlay_alpha` parameters to `InteractiveAnalyzer` and `analyse_interactive()` with input validation
- Extract reusable `_create_overlay_rgba()` helper for building RGBA masks from binary ground truth
- Load ground truth mask (`/GroundTruth/DefectMask`) in interactive analyzer; skip "Show GT" checkbox when no defects exist
- Implement toggleable ground truth overlay with RGBA image + contour outline, persisting across frame changes
- Restructure figure layout to `GridSpec` with dedicated bottom row for controls, preventing widget overlap with plot labels