### PR TITLE
Harden repo against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "skip-news"
@@ -14,6 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "skip-news"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
         # Step 1: Checkout code in the specified release branch
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.ref }}
 
         # Step 2: Setup uv for building the package
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
@@ -40,7 +40,7 @@ jobs:
 
         # Step 4: Upload artifacts
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}
           activate-environment: true
           save-cache: false # Disable cache for pip build
+          restore-cache: false # Disable cache for pip build
 
         # Step 3: Build the package
       - name: Build package

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -54,7 +54,7 @@ jobs:
       # Step 1.1: Checkout repository (workflow_call) (see https://dev.to/koseimori/conditional-branching-with-workflowdispatch-and-workflowcall-in-github-actions-oik)
       - name: Checkout repository
         if: github.event.workflow != '.github/workflows/bump_version.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0  # Required for tags history
           ssh-key: ${{ secrets.WRITE_KEY }} # TODO: Replace with GitHub App: https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
@@ -63,7 +63,7 @@ jobs:
       # Step 1.2: Checkout repository (workflow_dispatch)
       - name: Checkout repository
         if: github.event.workflow == '.github/workflows/bump_version.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0  # Required for tags history
           ssh-key: ${{ secrets.WRITE_KEY }} # TODO: Replace with GitHub App: https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
@@ -71,7 +71,7 @@ jobs:
       # Step 2: Setup uv
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/code_ql.yml
+++ b/.github/workflows/code_ql.yml
@@ -20,19 +20,19 @@ jobs:
       # Step 1.1: Checkout repository (workflow_call) (see https://dev.to/koseimori/conditional-branching-with-workflowdispatch-and-workflowcall-in-github-actions-oik)
       - name: Checkout repository
         if: github.event.workflow != '.github/workflows/code_ql.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.ref }}
 
       # Step 1.2: Checkout repository (workflow_dispatch)
       - name: Checkout repository
         if: github.event.workflow == '.github/workflows/code_ql.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # Step 2: Setup uv
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/generate_diagrams.yml
+++ b/.github/workflows/generate_diagrams.yml
@@ -38,7 +38,7 @@ jobs:
       # Step 1.1: Checkout repository (workflow_call)
       - name: Checkout code
         if: github.event.workflow != '.github/workflows/generate_diagrams.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.ref }}
           ssh-key: ${{ secrets.WRITE_KEY }}
@@ -46,13 +46,13 @@ jobs:
       # Step 1.2: Checkout repository (workflow_dispatch)
       - name: Checkout code
         if: github.event.workflow == '.github/workflows/generate_diagrams.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ssh-key: ${{ secrets.WRITE_KEY }}
 
       # Step 2: Setup uv
       - name: Set up Python
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/generate_diagrams.yml
+++ b/.github/workflows/generate_diagrams.yml
@@ -119,7 +119,7 @@ jobs:
       # Step 7: Setup Node.js for Mermaid CLI
       - name: Setup Node.js for Mermaid CLI
         if: env.CHANGED == 'true'
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '20'
 

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -48,7 +48,7 @@ jobs:
           path: dist/
 
       - name: Sign artifacts and upload to GitHub Release
-        uses: sigstore/gh-action-sigstore-python@v3.3.0
+        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc
         with:
           inputs: |
             ./dist/*.tar.gz

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -30,7 +30,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
   # Job 3: Sign and upload release assets
   gh-release-assets:

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: build-artifacts
           path: dist/
@@ -42,7 +42,7 @@ jobs:
       id-token: write   # Required for Sigstore signing
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: build-artifacts
           path: dist/

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -32,7 +32,7 @@ jobs:
           pattern: coverage-data-python-*
 
       - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -27,7 +27,7 @@ jobs:
     needs: test
     steps:
       - name: Download coverage data
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: coverage-data-python-*
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       # Step 1: Checkout code with full history
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0  # Required for tags history
           ssh-key: ${{ secrets.WRITE_KEY }}
 
       # Step 2: Setup uv
       - name: Setup uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ vars.DEFAULT_PYTHON_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: build-artifacts
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,6 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,19 +23,19 @@ jobs:
       # Step 1.1: Checkout repository (workflow_call) (see https://dev.to/koseimori/conditional-branching-with-workflowdispatch-and-workflowcall-in-github-actions-oik)
       - name: Checkout repository
         if: github.event.workflow != '.github/workflows/tests.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ inputs.ref }}
 
       # Step 1.2: Checkout repository (workflow_dispatch)
       - name: Checkout repository
         if: github.event.workflow == '.github/workflows/tests.yml'
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # Step 2: Setup uv
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ matrix.python-version }}
@@ -62,7 +62,7 @@ jobs:
       # Step 5: Create artifact for coverage data
       - name: Upload coverage data
         if: matrix.python-version == vars.DEFAULT_PYTHON_VERSION
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: coverage-data-python-${{ matrix.python-version }}
           path: |

--- a/.github/workflows/update_cache.yml
+++ b/.github/workflows/update_cache.yml
@@ -19,12 +19,12 @@ jobs:
     steps:
       # Step 1: Checkout repository
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # Step 2: Setup uv
       - name: Setup uv
         id: setup-uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           version-file: requirements_dev.txt
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,10 @@ filename = "src/pythermondt/__pkginfo__.py"
 search = "__version__ = \"{current_version}\""
 replace = "__version__ = \"{new_version}\""
 
+# uv
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.licensecheck]
 skip_dependencies = [
     "azure-identity", # Buggy with complex license

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
     "pytest-benchmark==5.2.3",
-    "ruff==0.15.13",
+    "ruff==0.15.12",
     "pre-commit==4.6.0",
     "bump-my-version==1.3.0",
     "deepdiff==8.6.2",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 pytest==9.0.3
 pytest-cov==7.1.0
 pytest-benchmark==5.2.3
-ruff==0.15.13
+ruff==0.15.12
 pre-commit==4.6.0
 bump-my-version==1.3.0
 deepdiff==8.6.2


### PR DESCRIPTION
- Replace all GitHub Action version tags with immutable commit SHAs across 9 workflows — `actions/checkout`, `astral-sh/setup-uv`, `actions/upload-artifact`, `actions/download-artifact`, `actions/setup-node`, `pypa/gh-action-pypi-publish`, `sigstore/gh-action-sigstore-python`, and `MishaKav/pytest-coverage-comment`
- Add `restore-cache: false` to build workflow (both save and restore caching now disabled for reproducible builds)
- Add `[tool.uv] exclude-newer = "7 days"` in `pyproject.toml` to prevent uv from resolving packages published within the last 7 days
- Add 7-day `cooldown` for both pip and GitHub Actions dependabot updates to batch updates and reduce noise
- Downgrade ruff from 0.15.13 to 0.15.12 so uv's `exclude-newer` filter can resolve it

Follows [PyPI Security Best Practices Guide](https://github.com/lirantal/pypi-security-best-practices). Lockfiles aren't used because PyTorch wheel selection is incompatible with `uv lock` — all resolution uses the `uv pip` interface. Hash verification not yet implemented; cooldown is the primary defense.