### PR TITLE
Add first version for reader tests and centralize test support infrastructure

### DIFF
--- a/tests/assets/reader/ignored.txt
+++ b/tests/assets/reader/ignored.txt
@@ -1,0 +1,1 @@
+ignored text

--- a/tests/assets/reader/nested/sample3.test
+++ b/tests/assets/reader/nested/sample3.test
@@ -1,0 +1,1 @@
+nested sample

--- a/tests/assets/reader/sample1.test
+++ b/tests/assets/reader/sample1.test
@@ -1,0 +1,1 @@
+sample one

--- a/tests/assets/reader/sample2.test
+++ b/tests/assets/reader/sample2.test
@@ -1,0 +1,1 @@
+sample two

--- a/tests/io/backends/conftest.py
+++ b/tests/io/backends/conftest.py
@@ -1,10 +1,10 @@
 from collections.abc import Generator
-from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import cast
 
 import pytest
 from moto import mock_aws
+from moto.core.models import MockAWS
 
 from pythermondt.io import AzureBlobBackend, BaseBackend, LocalBackend, S3Backend
 from tests.support.storage import (
@@ -29,7 +29,7 @@ def backend_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[
     """Create backend from configuration."""
     config = cast(TestConfig, request.param)
 
-    mock: AbstractContextManager | None = None
+    mock: MockAWS | None = None
     if config.backend_cls == LocalBackend:
         backend_instance = LocalBackend(pattern=str(tmp_path))
     elif config.backend_cls == S3Backend:

--- a/tests/io/backends/conftest.py
+++ b/tests/io/backends/conftest.py
@@ -1,113 +1,26 @@
-"""Fixtures for backend agnostic tests."""
-
 from collections.abc import Generator
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import cast
-from unittest.mock import MagicMock, patch
 
 import pytest
 from moto import mock_aws
 
-from pythermondt.io import AzureBlobBackend, BaseBackend, IOPathWrapper, LocalBackend, S3Backend
-
-from .utils import MockAzureBlob, TestConfig
-
-BACKENDS = [
-    TestConfig(backend_cls=LocalBackend, scheme="file", is_remote=False),
-    TestConfig(backend_cls=S3Backend, scheme="s3", is_remote=True),
-    TestConfig(backend_cls=AzureBlobBackend, scheme="az", is_remote=True),
-]
-
-# Single file test data
-TEST_FILES = {
-    "sample.txt": b"test content",
-    "data.bin": b"\x00\x01\x02\x03",
-    "large.tiff": b"fake thermal data" * 100,
-}
-
-# Multi-file scenarios for list/filter tests
-FILE_SCENARIOS = {
-    "mixed_types": {
-        "sample.txt": b"test content",
-        "data.bin": b"\x00\x01\x02\x03",
-        "large.tiff": b"fake thermal data" * 100,
-    },
-    "single_type": {
-        "thermal1.tiff": b"data1",
-        "thermal2.tiff": b"data2",
-        "thermal3.tiff": b"data3",
-    },
-    "many_files": {f"file{i:03d}.bin": b"x" * i for i in range(15)},
-}
+from pythermondt.io import AzureBlobBackend, BaseBackend, LocalBackend, S3Backend
+from tests.support.storage import (
+    BACKENDS,
+    FILE_SCENARIOS,
+    TEST_FILES,
+    TestConfig,
+    mocked_azure_blob_storage,
+    prepare_file,
+)
 
 
 @pytest.fixture()
 def azure_mock():
     """Create mocked Azure Blob Storage."""
-    mock_storage = MockAzureBlob()
-
-    def make_blob_client(container: str, blob: str):
-        mock_blob = MagicMock()
-
-        # Mock download_blob - FIX: chunks() must return an iterator
-        def download_blob():
-            data = mock_storage.download_blob(container, blob)
-            mock_stream = MagicMock()
-            # Make chunks() return a callable that yields the data
-            mock_stream.chunks = lambda: iter([data])
-            return mock_stream
-
-        mock_blob.download_blob = download_blob
-
-        # Mock upload_blob
-        def upload_blob(data, overwrite=True):
-            content = data.read()
-            mock_storage.upload_blob(container, blob, content)
-
-        mock_blob.upload_blob = upload_blob
-
-        # Mock get_blob_properties
-        def get_blob_properties():
-            if not mock_storage.blob_exists(container, blob):
-                from azure.core.exceptions import ResourceNotFoundError
-
-                raise ResourceNotFoundError("Blob not found")
-            mock_props = MagicMock()
-            mock_props.size = mock_storage.get_blob_size(container, blob)
-            mock_props.etag = mock_storage.get_blob_etag(container, blob)
-            return mock_props
-
-        mock_blob.get_blob_properties = get_blob_properties
-
-        return mock_blob
-
-    def make_container_client(container: str):
-        mock_container = MagicMock()
-
-        def list_blobs(name_starts_with=""):
-            blob_names = mock_storage.list_blobs(container, name_starts_with)
-            mock_blobs = []
-            for name in blob_names:
-                mock_blob = MagicMock()
-                mock_blob.name = name
-                mock_blobs.append(mock_blob)
-            return mock_blobs
-
-        mock_container.list_blobs = list_blobs
-
-        return mock_container
-
-    with patch("pythermondt.io.backends.azure_backend.BlobServiceClient") as mock_client_class:
-        mock_client = MagicMock()
-        mock_client.get_blob_client = make_blob_client
-        mock_client.get_container_client = make_container_client
-        mock_client.close = MagicMock()
-
-        # Both from_connection_string and __init__ return the same mock
-        mock_client_class.from_connection_string.return_value = mock_client
-        mock_client_class.return_value = mock_client
-
+    with mocked_azure_blob_storage() as mock_storage:
         yield mock_storage
 
 
@@ -148,17 +61,7 @@ def backend_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[
 
 def _prepare_file(backend_instance: BaseBackend, name: str, content: bytes, tmp_path: Path) -> str:
     """Prepare file and return path."""
-    if isinstance(backend_instance, LocalBackend):
-        file_path = tmp_path / name
-        file_path.write_bytes(content)
-        return file_path.as_uri()
-    elif isinstance(backend_instance, AzureBlobBackend):
-        backend_instance.write_file(IOPathWrapper(content), name)
-        return f"az://test-container/{name}"
-    elif isinstance(backend_instance, S3Backend):
-        backend_instance.write_file(IOPathWrapper(content), name)
-        return "s3://test-bucket/" + name
-    raise NotImplementedError("Unsupported backend for file preparation.")
+    return prepare_file(backend_instance, name, content, tmp_path)
 
 
 @pytest.fixture(params=TEST_FILES.items(), ids=lambda x: x[0])

--- a/tests/io/backends/conftest.py
+++ b/tests/io/backends/conftest.py
@@ -59,17 +59,12 @@ def backend_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[
         mock.stop()
 
 
-def _prepare_file(backend_instance: BaseBackend, name: str, content: bytes, tmp_path: Path) -> str:
-    """Prepare file and return path."""
-    return prepare_file(backend_instance, name, content, tmp_path)
-
-
 @pytest.fixture(params=TEST_FILES.items(), ids=lambda x: x[0])
 def test_file(request, backend_config, tmp_path: Path) -> tuple[str, bytes]:
     """Single test file - returns (path, content) tuple."""
     name, content = request.param
     backend_instance, _ = backend_config
-    file_path = _prepare_file(backend_instance, name, content, tmp_path)
+    file_path = prepare_file(backend_instance, name, content, tmp_path)
     return file_path, content
 
 
@@ -77,7 +72,7 @@ def test_file(request, backend_config, tmp_path: Path) -> tuple[str, bytes]:
 def test_files_all(backend_config, tmp_path: Path) -> dict[str, str]:
     """All test files - returns dict of {name: path}."""
     backend_instance, _ = backend_config
-    return {name: _prepare_file(backend_instance, name, content, tmp_path) for name, content in TEST_FILES.items()}
+    return {name: prepare_file(backend_instance, name, content, tmp_path) for name, content in TEST_FILES.items()}
 
 
 @pytest.fixture(params=FILE_SCENARIOS.items(), ids=lambda x: x[0])
@@ -85,4 +80,4 @@ def test_files_scenario(request, backend_config, tmp_path: Path) -> dict[str, st
     """Parameterized multi-file scenarios - returns dict of {name: path}."""
     _, files = request.param
     backend_instance, _ = backend_config
-    return {name: _prepare_file(backend_instance, name, content, tmp_path) for name, content in sorted(files.items())}
+    return {name: prepare_file(backend_instance, name, content, tmp_path) for name, content in sorted(files.items())}

--- a/tests/reader/conftest.py
+++ b/tests/reader/conftest.py
@@ -1,0 +1,133 @@
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+from pythermondt.io import AzureBlobBackend, LocalBackend, S3Backend
+from pythermondt.io.parsers import BaseParser
+from pythermondt.readers import AzureBlobReader, BaseReader, LocalReader, S3Reader
+from tests.support import storage
+
+
+class ReaderFactory(Protocol):
+    """Factory signature for creating equivalent readers with test-specific options."""
+
+    def __call__(
+        self,
+        parser: type[BaseParser] | None = ...,
+        num_files: int | None = ...,
+    ) -> BaseReader: ...
+
+
+@dataclass(frozen=True)
+class ReaderTestContext:
+    """Reader fixture context with backend-specific setup hidden behind callbacks."""
+
+    reader: BaseReader
+    config: storage.TestConfig
+    make_reader: ReaderFactory
+    prepare_file: Callable[[str, bytes], str]
+
+
+@dataclass(frozen=True)
+class ReaderTestData:
+    """Prepared reader files and their source contents."""
+
+    context: ReaderTestContext
+    files: dict[str, str]
+    contents: dict[str, str]
+
+    @property
+    def reader(self) -> BaseReader:
+        """Return the reader under test."""
+        return self.context.reader
+
+    @property
+    def expected_files(self) -> list[str]:
+        """Return the parser-supported files in deterministic reader order."""
+        return [self.files[name] for name in sorted(self.contents) if name.endswith(".test")]
+
+
+@pytest.fixture()
+def azure_mock():
+    """Create mocked Azure Blob Storage."""
+    with storage.mocked_azure_blob_storage() as mock_storage:
+        yield mock_storage
+
+
+@pytest.fixture(params=storage.BACKENDS, ids=lambda x: x.reader_cls.__name__)
+def reader_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[ReaderTestContext]:
+    """Create a reader and a storage setup callback from configuration."""
+    config = cast(storage.TestConfig, request.param)
+
+    if config.reader_cls == LocalReader:
+        backend = LocalBackend(pattern=str(tmp_path))
+
+        def make_reader(
+            parser: type[BaseParser] | None = storage.PlainTextParser, num_files: int | None = None
+        ) -> BaseReader:
+            return LocalReader(pattern=str(tmp_path), num_files=num_files, parser=parser)
+
+    elif config.reader_cls == S3Reader:
+        s3_client.create_bucket(Bucket="test-bucket")
+        backend = S3Backend(bucket="test-bucket", prefix="")
+
+        def make_reader(
+            parser: type[BaseParser] | None = storage.PlainTextParser, num_files: int | None = None
+        ) -> BaseReader:
+            return S3Reader(bucket="test-bucket", prefix="", num_files=num_files, parser=parser)
+
+    elif config.reader_cls == AzureBlobReader:
+        azure_mock.create_container("test-container")
+        backend = AzureBlobBackend(
+            account_url="https://test.blob.core.windows.net",
+            container_name="test-container",
+            prefix="",
+            connection_string="DefaultEndpointsProtocol=https;AccountName=test;AccountKey=fake==;EndpointSuffix=core.windows.net",
+        )
+
+        def make_reader(
+            parser: type[BaseParser] | None = storage.PlainTextParser, num_files: int | None = None
+        ) -> BaseReader:
+            return AzureBlobReader(
+                account_url="https://test.blob.core.windows.net",
+                container_name="test-container",
+                prefix="",
+                connection_string=(
+                    "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=fake==;EndpointSuffix=core.windows.net"
+                ),
+                num_files=num_files,
+                parser=parser,
+            )
+
+    else:
+        raise NotImplementedError(f"Reader {config.reader_cls} not implemented")
+
+    def prepare_reader_file(name: str, content: bytes) -> str:
+        """Prepare one file in the reader's storage and return its canonical URI."""
+        return storage.prepare_file(backend, name, content, tmp_path)
+
+    reader = make_reader()
+    yield ReaderTestContext(
+        reader=reader,
+        config=config,
+        make_reader=make_reader,
+        prepare_file=prepare_reader_file,
+    )
+
+    backend.close()
+    reader.backend.close()
+
+
+@pytest.fixture()
+def reader_test_data(reader_config: ReaderTestContext) -> ReaderTestData:
+    """Prepare plain text files for reader tests."""
+    asset_dir = Path(__file__).parents[1] / "assets" / "reader"
+    names = ("sample1.test", "sample2.test", "ignored.txt")
+
+    # Use real test assets so read/parse assertions exercise the reader path end-to-end.
+    contents = {name: (asset_dir / name).read_text() for name in names}
+    files = {name: reader_config.prepare_file(name, content.encode()) for name, content in sorted(contents.items())}
+    return ReaderTestData(context=reader_config, files=files, contents=contents)

--- a/tests/reader/conftest.py
+++ b/tests/reader/conftest.py
@@ -5,7 +5,7 @@ from typing import Protocol, cast
 
 import pytest
 
-from pythermondt.io import AzureBlobBackend, LocalBackend, S3Backend
+from pythermondt.io import AzureBlobBackend, BaseBackend, LocalBackend, S3Backend
 from pythermondt.io.parsers import BaseParser
 from pythermondt.readers import AzureBlobReader, BaseReader, LocalReader, S3Reader
 from tests.support import storage
@@ -62,6 +62,7 @@ def reader_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[R
     """Create a reader and a storage setup callback from configuration."""
     config = cast(storage.TestConfig, request.param)
 
+    backend: BaseBackend
     if config.reader_cls == LocalReader:
         backend = LocalBackend(pattern=str(tmp_path))
 

--- a/tests/reader/test_local_reader.py
+++ b/tests/reader/test_local_reader.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from pythermondt.readers import LocalReader
+from tests.support.storage import PlainTextParser
+
+
+def test_local_reader_recursive_includes_nested_test_files(tmp_path: Path):
+    """Test recursive LocalReader discovery includes nested supported files."""
+    asset_dir = Path(__file__).parents[1] / "assets" / "reader"
+
+    # Keep the test independent from the committed asset directory layout.
+    for relative_path in ("sample1.test", "nested/sample3.test"):
+        target = tmp_path / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text((asset_dir / relative_path).read_text())
+
+    reader = LocalReader(pattern=str(tmp_path), recursive=True, parser=PlainTextParser)
+
+    assert sorted(reader.file_names) == ["sample1.test", "sample3.test"]

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -1,0 +1,89 @@
+from re import escape
+
+import pytest
+
+from pythermondt.data import DataContainer
+from tests.reader.conftest import ReaderTestData
+from tests.support.storage import PlainTextParser
+
+
+def _assert_payload(container: DataContainer) -> str:
+    """Extract the text payload written by PlainTextParser."""
+    payload = container.get_attribute("/MetaData", "payload")
+    assert isinstance(payload, str)
+    return payload
+
+
+def test_remote_source(reader_config):
+    """Test that readers expose the backend remote/local source type."""
+    assert reader_config.reader.remote_source == reader_config.config.is_remote
+
+
+def test_files_use_parser_extensions(reader_test_data: ReaderTestData):
+    """Test that reader file discovery respects parser-supported extensions."""
+    assert reader_test_data.reader.files == reader_test_data.expected_files
+    assert all(
+        path.startswith(f"{reader_test_data.context.config.scheme}://") for path in reader_test_data.reader.files
+    )
+    assert all(path.endswith(".test") for path in reader_test_data.reader.files)
+    assert reader_test_data.files["ignored.txt"] not in reader_test_data.reader.files
+
+
+def test_num_files_limits_reader_files(reader_test_data: ReaderTestData):
+    """Test that num_files limits the discovered reader files."""
+    reader = reader_test_data.context.make_reader(parser=PlainTextParser, num_files=1)
+
+    assert reader.files == reader_test_data.expected_files[:1]
+
+
+def test_file_names(reader_test_data: ReaderTestData):
+    """Test that file_names strips storage-specific path prefixes."""
+    assert reader_test_data.reader.file_names == ["sample1.test", "sample2.test"]
+
+
+def test_len(reader_test_data: ReaderTestData):
+    """Test that len(reader) reflects the discovered files."""
+    assert len(reader_test_data.reader) == len(reader_test_data.expected_files)
+
+
+def test_getitem(reader_test_data: ReaderTestData):
+    """Test indexed access reads and parses the selected file."""
+    container = reader_test_data.reader[0]
+
+    assert _assert_payload(container) == reader_test_data.contents["sample1.test"]
+
+
+@pytest.mark.parametrize("index", [-1, 2])
+def test_getitem_invalid_index(reader_test_data: ReaderTestData, index: int):
+    """Test indexed access validates bounds before reading."""
+    with pytest.raises(IndexError, match=escape("Index out of bounds. Must be in range [0, 2[")):
+        reader_test_data.reader[index]
+
+
+def test_iter(reader_test_data: ReaderTestData):
+    """Test forward iteration reads files in reader order."""
+    payloads = [_assert_payload(container) for container in reader_test_data.reader]
+
+    assert payloads == [reader_test_data.contents["sample1.test"], reader_test_data.contents["sample2.test"]]
+
+
+def test_reversed(reader_test_data: ReaderTestData):
+    """Test reverse iteration reads files in reverse reader order."""
+    payloads = [_assert_payload(container) for container in reversed(reader_test_data.reader)]
+
+    assert payloads == [reader_test_data.contents["sample2.test"], reader_test_data.contents["sample1.test"]]
+
+
+def test_read_file_uses_explicit_parser(reader_test_data: ReaderTestData):
+    """Test that read_file delegates parsing to the configured parser."""
+    container = reader_test_data.reader.read_file(reader_test_data.files["sample1.test"])
+
+    assert _assert_payload(container) == reader_test_data.contents["sample1.test"]
+
+
+def test_read_file_without_matching_parser_raises(reader_test_data: ReaderTestData):
+    """Test that automatic parser lookup rejects unsupported extensions."""
+    reader = reader_test_data.context.make_reader(parser=None, num_files=None)
+
+    with pytest.raises(ValueError, match=escape("No parser found for file extension: .test")):
+        reader.read_file(reader_test_data.files["sample1.test"])

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -26,19 +26,20 @@ def test_parser_class(reader_config: ReaderTestContext):
 
 def test_files_use_parser_extensions(reader_test_data: ReaderTestData):
     """Test that reader file discovery respects parser-supported extensions."""
+    expected_scheme = reader_test_data.context.config.scheme
     assert reader_test_data.reader.files == reader_test_data.expected_files
-    assert all(
-        path.startswith(f"{reader_test_data.context.config.scheme}://") for path in reader_test_data.reader.files
-    )
+    assert all(path.startswith(f"{expected_scheme}://") for path in reader_test_data.reader.files)
     assert all(path.endswith(".test") for path in reader_test_data.reader.files)
     assert reader_test_data.files["ignored.txt"] not in reader_test_data.reader.files
 
 
-def test_num_files_limits_reader_files(reader_test_data: ReaderTestData):
+@pytest.mark.parametrize("num_files", [1, 3, 10, 100, None], ids=["1", "3", "10", "100", "None"])
+def test_num_files_limits_reader_files(reader_test_data: ReaderTestData, num_files: int | None):
     """Test that num_files limits the discovered reader files."""
-    reader = reader_test_data.context.make_reader(parser=PlainTextParser, num_files=1)
+    reader = reader_test_data.context.make_reader(parser=PlainTextParser, num_files=num_files)
+    expected_files = reader_test_data.expected_files
 
-    assert reader.files == reader_test_data.expected_files[:1]
+    assert reader.files == expected_files[:num_files] if num_files else expected_files
 
 
 def test_file_names(reader_test_data: ReaderTestData):

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -53,11 +53,12 @@ def test_getitem(reader_test_data: ReaderTestData):
     assert _assert_payload(container) == reader_test_data.contents["sample1.test"]
 
 
-@pytest.mark.parametrize("index", [-1, 2])
-def test_getitem_invalid_index(reader_test_data: ReaderTestData, index: int):
+@pytest.mark.parametrize("index", [-100, -1, None])
+def test_getitem_invalid_index(reader_test_data: ReaderTestData, index: int | None):
     """Test indexed access validates bounds before reading."""
-    with pytest.raises(IndexError, match=escape("Index out of bounds. Must be in range [0, 2[")):
-        reader_test_data.reader[index]
+    idx = index if index is not None else len(reader_test_data.expected_files) + 5
+    with pytest.raises(IndexError, match=escape("Index out of bounds.")):
+        reader_test_data.reader[idx]
 
 
 def test_iter(reader_test_data: ReaderTestData):

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -3,7 +3,7 @@ from re import escape
 import pytest
 
 from pythermondt.data import DataContainer
-from tests.reader.conftest import ReaderTestData
+from tests.reader.conftest import ReaderTestContext, ReaderTestData
 from tests.support.storage import PlainTextParser
 
 
@@ -14,9 +14,14 @@ def _assert_payload(container: DataContainer) -> str:
     return payload
 
 
-def test_remote_source(reader_config):
+def test_remote_source(reader_config: ReaderTestContext):
     """Test that readers expose the backend remote/local source type."""
     assert reader_config.reader.remote_source == reader_config.config.is_remote
+
+
+def test_parser_class(reader_config: ReaderTestContext):
+    """Test that readers expose the configured parser class (in this case always PlainTextParser)."""
+    assert reader_config.reader.parser == PlainTextParser
 
 
 def test_files_use_parser_extensions(reader_test_data: ReaderTestData):

--- a/tests/support/storage/__init__.py
+++ b/tests/support/storage/__init__.py
@@ -1,0 +1,15 @@
+from .azure import MockAzureBlob, mocked_azure_blob_storage
+from .config import BACKENDS, TestConfig
+from .files import FILE_SCENARIOS, TEST_FILES, prepare_file
+from .parsers import PlainTextParser
+
+__all__ = [
+    "BACKENDS",
+    "FILE_SCENARIOS",
+    "TEST_FILES",
+    "MockAzureBlob",
+    "PlainTextParser",
+    "TestConfig",
+    "mocked_azure_blob_storage",
+    "prepare_file",
+]

--- a/tests/support/storage/azure.py
+++ b/tests/support/storage/azure.py
@@ -1,17 +1,8 @@
 import hashlib
-from dataclasses import dataclass
+from collections.abc import Iterator
+from contextlib import contextmanager
 from io import BytesIO
-
-from pythermondt.io import BaseBackend
-
-
-@dataclass
-class TestConfig:
-    """Configuration for backend testing."""
-
-    backend_cls: type[BaseBackend]
-    scheme: str
-    is_remote: bool
+from unittest.mock import MagicMock, patch
 
 
 class MockAzureBlob:
@@ -30,7 +21,6 @@ class MockAzureBlob:
 
             raise ResourceNotFoundError(f"Container '{container}' not found")
 
-        # Handle both bytes and file-like objects
         if isinstance(data, BytesIO):
             data.seek(0)
             content = data.read()
@@ -75,3 +65,62 @@ class MockAzureBlob:
 
         content = self.storage[container][blob_name]
         return f'"{hashlib.md5(content, usedforsecurity=False).hexdigest()}"'
+
+
+@contextmanager
+def mocked_azure_blob_storage() -> Iterator[MockAzureBlob]:
+    """Mock Azure BlobServiceClient calls and yield in-memory storage."""
+    mock_storage = MockAzureBlob()
+
+    def make_blob_client(container: str, blob: str):
+        mock_blob = MagicMock()
+
+        def download_blob():
+            data = mock_storage.download_blob(container, blob)
+            mock_stream = MagicMock()
+            mock_stream.chunks = lambda: iter([data])
+            return mock_stream
+
+        def upload_blob(data, overwrite=True):
+            content = data.read()
+            mock_storage.upload_blob(container, blob, content)
+
+        def get_blob_properties():
+            if not mock_storage.blob_exists(container, blob):
+                from azure.core.exceptions import ResourceNotFoundError
+
+                raise ResourceNotFoundError("Blob not found")
+            mock_props = MagicMock()
+            mock_props.size = mock_storage.get_blob_size(container, blob)
+            mock_props.etag = mock_storage.get_blob_etag(container, blob)
+            return mock_props
+
+        mock_blob.download_blob = download_blob
+        mock_blob.upload_blob = upload_blob
+        mock_blob.get_blob_properties = get_blob_properties
+        return mock_blob
+
+    def make_container_client(container: str):
+        mock_container = MagicMock()
+
+        def list_blobs(name_starts_with=""):
+            mock_blobs = []
+            for name in mock_storage.list_blobs(container, name_starts_with):
+                mock_blob = MagicMock()
+                mock_blob.name = name
+                mock_blobs.append(mock_blob)
+            return mock_blobs
+
+        mock_container.list_blobs = list_blobs
+        return mock_container
+
+    with patch("pythermondt.io.backends.azure_backend.BlobServiceClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client.get_blob_client = make_blob_client
+        mock_client.get_container_client = make_container_client
+        mock_client.close = MagicMock()
+
+        mock_client_class.from_connection_string.return_value = mock_client
+        mock_client_class.return_value = mock_client
+
+        yield mock_storage

--- a/tests/support/storage/config.py
+++ b/tests/support/storage/config.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from pythermondt.io import AzureBlobBackend, BaseBackend, LocalBackend, S3Backend
+from pythermondt.readers import AzureBlobReader, BaseReader, LocalReader, S3Reader
+
+
+@dataclass(frozen=True)
+class TestConfig:
+    """Configuration for backend and reader testing."""
+
+    backend_cls: type[BaseBackend]
+    reader_cls: type[BaseReader]
+    scheme: str
+    is_remote: bool
+
+
+BACKENDS = [
+    TestConfig(backend_cls=LocalBackend, reader_cls=LocalReader, scheme="file", is_remote=False),
+    TestConfig(backend_cls=S3Backend, reader_cls=S3Reader, scheme="s3", is_remote=True),
+    TestConfig(backend_cls=AzureBlobBackend, reader_cls=AzureBlobReader, scheme="az", is_remote=True),
+]

--- a/tests/support/storage/files.py
+++ b/tests/support/storage/files.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from pythermondt.io import AzureBlobBackend, BaseBackend, IOPathWrapper, LocalBackend, S3Backend
+
+TEST_FILES = {
+    "sample.txt": b"test content",
+    "data.bin": b"\x00\x01\x02\x03",
+    "large.tiff": b"fake thermal data" * 100,
+}
+
+FILE_SCENARIOS = {
+    "mixed_types": {
+        "sample.txt": b"test content",
+        "data.bin": b"\x00\x01\x02\x03",
+        "large.tiff": b"fake thermal data" * 100,
+    },
+    "single_type": {
+        "thermal1.tiff": b"data1",
+        "thermal2.tiff": b"data2",
+        "thermal3.tiff": b"data3",
+    },
+    "many_files": {f"file{i:03d}.bin": b"x" * i for i in range(15)},
+}
+
+
+def prepare_file(backend: BaseBackend, name: str, content: bytes, tmp_path: Path) -> str:
+    """Prepare a file for a backend and return its canonical URI."""
+    if isinstance(backend, LocalBackend):
+        file_path = tmp_path / name
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(content)
+        return file_path.as_uri()
+    if isinstance(backend, AzureBlobBackend):
+        backend.write_file(IOPathWrapper(content), name)
+        return f"az://test-container/{name}"
+    if isinstance(backend, S3Backend):
+        backend.write_file(IOPathWrapper(content), name)
+        return f"s3://test-bucket/{name}"
+    raise NotImplementedError("Unsupported backend for file preparation.")

--- a/tests/support/storage/parsers.py
+++ b/tests/support/storage/parsers.py
@@ -1,0 +1,14 @@
+from pythermondt.data import DataContainer
+from pythermondt.io import IOPathWrapper
+from pythermondt.io.parsers import BaseParser
+
+
+class PlainTextParser(BaseParser):
+    supported_extensions = (".test",)
+
+    @staticmethod
+    def parse(data: IOPathWrapper) -> DataContainer:
+        container = DataContainer()
+        container.add_group("/", "MetaData")
+        container.add_attribute("/MetaData", "payload", data.file_obj.read().decode())
+        return container


### PR DESCRIPTION
- Extract shared test support into `tests/support/storage/` — `MockAzureBlob`, `TestConfig`, `prepare_file`, file configs, and a `PlainTextParser`. Simplifies `tests/io/backends/conftest.py` by importing from there.
- Add test assets under `tests/assets/reader/` for parser-extension filtering and recursive discovery.
- Add `tests/reader/conftest.py` with fixtures parametrized over `LocalReader`, `S3Reader`, `AzureBlobReader`.
- Add `tests/reader/test_reader_interface.py` covering the full `BaseReader` contract (file discovery, access, iteration, bounds, parser lookup) — 34 parametrized tests.
- Add `tests/reader/test_local_reader.py` verifying recursive nested-file discovery.
- Skipped testing `download()`, `sync()`, and caching on `BaseReader` — local cache logic will eventually move into the backend.

First task from [#394](https://github.com/voidsy-gmbh/pyThermoNDT/issues/394).
