### PR TITLE
Export AzureBlobReader, AzureBlobWriter, and frequency module at package top level

### DIFF
--- a/src/pythermondt/__init__.py
+++ b/src/pythermondt/__init__.py
@@ -5,15 +5,17 @@ from .config import configure_logging, settings
 from .data import DataContainer, ThermoContainer
 from .dataset import IndexedThermoDataset, ThermoDataset
 from .io import HDF5Parser, SimulationParser
-from .readers import LocalReader, S3Reader
-from .transforms import augmentation, normalization, preprocessing, sampling, utils
-from .writers import LocalWriter, S3Writer
+from .readers import AzureBlobReader, LocalReader, S3Reader
+from .transforms import augmentation, frequency, normalization, preprocessing, sampling, utils
+from .writers import AzureBlobWriter, LocalWriter, S3Writer
 
 # Set up logging per Python best practices: https://docs.python.org/3/howto/logging.html
 # Add NullHandler to prevent "No handlers could be found" warnings
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
+    "AzureBlobReader",
+    "AzureBlobWriter",
     "DataContainer",
     "HDF5Parser",
     "IndexedThermoDataset",
@@ -27,6 +29,7 @@ __all__ = [
     "__version__",
     "augmentation",
     "configure_logging",
+    "frequency",
     "normalization",
     "preprocessing",
     "sampling",


### PR DESCRIPTION
- Expose `AzureBlobReader` and `AzureBlobWriter` in `pythermondt.__init__` imports and `__all__`
- Add the `frequency` transform module to the public API surface via package-level import and `__all__`

This makes the Azure reader/writer classes and frequency-domain transforms importable directly from `pythermondt` instead of requiring deeper relative imports.