### PR TITLE
Move filtering and sorting logic from backends into BaseReader

### DIFF
--- a/src/pythermondt/io/backends/azure_backend.py
+++ b/src/pythermondt/io/backends/azure_backend.py
@@ -168,16 +168,8 @@ class AzureBlobBackend(BaseBackend):
         """
         self.__client.close()
 
-    def get_file_list(self, extensions: tuple[str, ...] | None = None, num_files: int | None = None) -> list[str]:
-        """Get list of files from Azure Blob Storage with optional filtering.
-
-        Args:
-            extensions (tuple[str, ...], optional): Filter by file extensions
-            num_files (int, optional): Limit number of files returned
-
-        Returns:
-            list[str]: List of file paths
-        """
+    def get_file_list(self) -> list[str]:
+        """Return all blobs under the configured prefix as unsorted Azure URIs."""
         blobs = []
         container_client = self.__client.get_container_client(self.__container_name)
 
@@ -187,14 +179,6 @@ class AzureBlobBackend(BaseBackend):
 
             # Add full Azure path using _to_url
             blobs.append(self._to_url(self.__container_name, blob.name))
-
-        if extensions:
-            blobs = [b for b in blobs if any(b.lower().endswith(ext.lower()) for ext in extensions)]
-
-        blobs.sort()
-
-        if num_files is not None:
-            blobs = blobs[:num_files]
 
         return blobs
 

--- a/src/pythermondt/io/backends/base_backend.py
+++ b/src/pythermondt/io/backends/base_backend.py
@@ -37,8 +37,8 @@ class BaseBackend(ABC):
         raise NotImplementedError("Subclasses must implement this method")
 
     @abstractmethod
-    def get_file_list(self, extensions: tuple[str, ...] | None = None, num_files: int | None = None) -> list[str]:
-        """Get a list of files matching the specified pattern/extensions."""
+    def get_file_list(self) -> list[str]:
+        """Return all files under the configured pattern or prefix as unsorted URIs."""
         raise NotImplementedError("Subclasses must implement this method")
 
     @abstractmethod

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -76,7 +76,7 @@ class LocalBackend(BaseBackend):
         # Nothing to close for local files
         pass
 
-    def get_file_list(self, extensions: tuple[str, ...] | None = None, num_files: int | None = None) -> list[str]:
+    def get_file_list(self) -> list[str]:
         # Handle different pattern types
         all_files = []
         match self.__source_type:
@@ -89,17 +89,6 @@ class LocalBackend(BaseBackend):
                     all_files = [f.path for f in os.scandir(self.pattern) if f.is_file()]
             case "glob":
                 all_files = glob(self.pattern, recursive=self.__recursive)
-
-        # Filter by extension if provided
-        if extensions:
-            all_files = [f for f in all_files if any(f.endswith(ext) for ext in extensions)]
-
-        # Sort for deterministic behavior
-        all_files.sort()
-
-        # Limit number of results if specified
-        if num_files is not None:
-            all_files = all_files[:num_files]
 
         # Convert to absolute paths and normalize before returning
         all_files = [self._to_url(os.path.normpath(os.path.abspath(f))) for f in all_files]

--- a/src/pythermondt/io/backends/s3_backend.py
+++ b/src/pythermondt/io/backends/s3_backend.py
@@ -121,16 +121,8 @@ class S3Backend(BaseBackend):
         """
         self.__client.close()
 
-    def get_file_list(self, extensions: tuple[str, ...] | None = None, num_files: int | None = None) -> list[str]:
-        """Get list of files from S3 with optional filtering.
-
-        Args:
-            extensions (tuple[str, ...], optional): Filter by file extensions
-            num_files (int, optional): Limit number of files returned
-
-        Returns:
-            list[str]: List of file paths
-        """
+    def get_file_list(self) -> list[str]:
+        """Return all objects under the configured prefix as unsorted S3 URIs."""
         # List all objects with the given prefix
         paginator = self.__client.get_paginator("list_objects_v2")
 
@@ -145,17 +137,6 @@ class S3Backend(BaseBackend):
 
                     # Add full S3 path
                     files.append(self._to_url(self.bucket, key))
-
-        # Filter by extension if provided
-        if extensions:
-            files = [f for f in files if any(f.lower().endswith(ext.lower()) for ext in extensions)]
-
-        # Sort for deterministic behavior
-        files.sort()
-
-        # Limit results if specified
-        if num_files is not None:
-            files = files[:num_files]
 
         return files
 

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -152,13 +152,11 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         """List of URL-encoded URIs for internal use (reading, downloading, caching)."""
         # If caching is disabled return the file list from the backend
         if not self.__cache_files:
-            return self.backend.get_file_list(extensions=self.__supported_extensions, num_files=self.num_files)
+            return self._filter_and_limit(self.backend.get_file_list())
 
         # If URIs have never been loaded, load them from the backend
         if self.__file_uris is None:
-            self.__file_uris = self.backend.get_file_list(
-                extensions=self.__supported_extensions, num_files=self.num_files
-            )
+            self.__file_uris = self._filter_and_limit(self.backend.get_file_list())
 
         # Return the cached URIs list
         return self.__file_uris
@@ -233,6 +231,24 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     def _to_file_name(self, file_path: str) -> str:
         """Extract the file name from a file path."""
         return os.path.basename(unquote(urlparse(file_path).path))
+
+    def _filter_and_limit(self, files: list[str]) -> list[str]:
+        """Apply extension filtering, sort, and num_files limit.
+
+        Filtering is applied in the reader so backends stay portable and only
+        need to return the complete, unfiltered file listing.
+        """
+        # Filter by extension if provided
+        if self.__supported_extensions:
+            files = [f for f in files if any(f.endswith(ext) for ext in self.__supported_extensions)]
+
+        # Sort for deterministic behavior
+        files.sort()
+
+        # Limit number of results if specified
+        if self.num_files is not None:
+            files = files[: self.num_files]
+        return files
 
     def _load_manifest(self, manifest_path: str) -> CacheManifest:
         """Load manifest from disk with thread safety."""

--- a/tests/io/backends/test_backend_interface.py
+++ b/tests/io/backends/test_backend_interface.py
@@ -143,49 +143,21 @@ def test_get_file_list(backend_config, test_file):
     """Test listing a single file without any filters."""
     backend_instance, config = backend_config
     file_path, _ = test_file
-    expected_files = [file_path]
     file_list = backend_instance.get_file_list()
 
     assert len(file_list) == 1
     assert file_list[0].startswith(config.scheme + "://")
-    assert file_list == expected_files
+    assert set(file_list) == {file_path}
 
 
 def test_get_file_list_all(backend_config, test_files_scenario):
     """Test listing all files."""
     backend_instance, config = backend_config
-    expected_files = list(test_files_scenario.values())
     file_list = backend_instance.get_file_list()
 
     assert len(file_list) == len(test_files_scenario)
     assert all(f.startswith(config.scheme + "://") for f in file_list)
-    assert file_list == expected_files
-
-
-def test_get_file_list_filter_extension(backend_config, test_files_scenario):
-    """Test extension filtering."""
-    backend_instance, config = backend_config
-
-    # Count expected .tiff files in scenario
-    expected_tiff = [name for name in test_files_scenario.values() if name.endswith(".tiff")]
-    file_list = backend_instance.get_file_list(extensions=(".tiff",))
-
-    assert len(file_list) == len(expected_tiff)
-    assert all(f.startswith(config.scheme + "://") for f in file_list)
-    assert file_list == expected_tiff
-
-
-@pytest.mark.parametrize("num_files", [0, 1, 5])
-def test_get_file_list_num_limit(backend_config, test_files_scenario, num_files):
-    """Test num_files limit."""
-    backend_instance, config = backend_config
-
-    expected_files = list(test_files_scenario.values())[0:num_files]
-    limited = backend_instance.get_file_list(num_files=num_files)
-
-    assert len(limited) == len(expected_files)
-    assert all(f.startswith(config.scheme + "://") for f in limited)
-    assert limited == expected_files
+    assert set(file_list) == set(test_files_scenario.values())
 
 
 def test_download_file(backend_config, tmp_path, test_file):

--- a/tests/io/backends/test_local_backend.py
+++ b/tests/io/backends/test_local_backend.py
@@ -112,7 +112,7 @@ def test_get_file_list_single_file(tmp_path: Path):
 def test_get_file_list_directory(tmp_path: Path):
     """Test get_file_list with directory pattern."""
     files = ["test1.txt", "test2.py", "test3.txt"]
-    paths = sorted(tmp_path / filename for filename in files)  # Should be sorted to match the backend's behavior
+    paths = [tmp_path / filename for filename in files]
 
     for path in paths:
         path.write_text("content")
@@ -120,10 +120,10 @@ def test_get_file_list_directory(tmp_path: Path):
     backend = LocalBackend(str(tmp_path))
 
     result = backend.get_file_list()
-    expected = [p.as_uri() for p in paths]  # Convert path objects to strings for comparison
+    expected = {p.as_uri() for p in paths}
 
     assert len(result) == 3
-    assert result == expected
+    assert set(result) == expected
 
 
 def test_get_file_list_glob_pattern(tmp_path: Path):

--- a/tests/io/backends/test_local_backend.py
+++ b/tests/io/backends/test_local_backend.py
@@ -152,23 +152,6 @@ def test_get_file_list_empty_directory(tmp_path):
     assert len(result) == 0
 
 
-def test_get_file_list_sorting(tmp_path):
-    """Test that get_file_list returns sorted results."""
-    files = ["zebra.txt", "alpha.txt", "beta.txt"]
-    for filename in files:
-        (tmp_path / filename).write_text("content")
-
-    backend = LocalBackend(str(tmp_path))
-    result = backend.get_file_list()
-
-    # Check that results are sorted (regardless of path separator format)
-    assert len(result) == 3
-    assert result == sorted(result)
-    # Check that all expected filenames are present
-    result_names = [Path(f).name for f in result]
-    assert result_names == ["alpha.txt", "beta.txt", "zebra.txt"]
-
-
 def test_unicode_filenames(tmp_path):
     """Test handling files with unicode characters."""
     backend = LocalBackend(str(tmp_path))

--- a/tests/io/backends/test_local_backend.py
+++ b/tests/io/backends/test_local_backend.py
@@ -204,7 +204,9 @@ def test_full_workflow(tmp_path):
     all_files = backend.get_file_list()
     assert len(all_files) == 4
 
-    txt_files = backend.get_file_list(extensions=(".txt",))
+    # Test listing filtered by extension (filtering is a reader concern;
+    # backends return all files, so we filter manually here for the test)
+    txt_files = [f for f in all_files if f.endswith(".txt")]
     assert len(txt_files) == 2
 
     # Test reading

--- a/tests/io/backends/test_local_backend.py
+++ b/tests/io/backends/test_local_backend.py
@@ -144,41 +144,6 @@ def test_get_file_list_glob_pattern(tmp_path: Path):
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    "extensions, expected_count",
-    [
-        ((".txt",), 2),
-        ((".py",), 1),
-        ((".txt", ".py"), 3),
-        ((".md",), 0),
-    ],
-)
-def test_get_file_list_extension_filter(tmp_path, extensions, expected_count):
-    """Test get_file_list with extension filtering."""
-    files = ["test1.txt", "test2.py", "test3.txt"]
-    for filename in files:
-        (tmp_path / filename).write_text("content")
-
-    backend = LocalBackend(str(tmp_path))
-    result = backend.get_file_list(extensions=extensions)
-
-    assert len(result) == expected_count
-    if expected_count > 0:
-        assert all(f.endswith(extensions) for f in result)
-
-
-def test_get_file_list_num_files_limit(tmp_path):
-    """Test get_file_list with number limit."""
-    files = ["test1.txt", "test2.txt", "test3.txt", "test4.txt"]
-    for filename in files:
-        (tmp_path / filename).write_text("content")
-
-    backend = LocalBackend(str(tmp_path))
-    result = backend.get_file_list(num_files=2)
-
-    assert len(result) == 2
-
-
 def test_get_file_list_empty_directory(tmp_path):
     """Test get_file_list with empty directory."""
     backend = LocalBackend(str(tmp_path))

--- a/tests/io/backends/test_local_backend.py
+++ b/tests/io/backends/test_local_backend.py
@@ -129,7 +129,7 @@ def test_get_file_list_directory(tmp_path: Path):
 def test_get_file_list_glob_pattern(tmp_path: Path):
     """Test get_file_list with glob pattern."""
     files = ["test1.txt", "test2.py", "other.txt"]
-    paths = sorted(tmp_path / filename for filename in files)  # Should be sorted to match the backend's behavior
+    paths = [tmp_path / filename for filename in files]
 
     for path in paths:
         path.write_text("content")


### PR DESCRIPTION
- Removed `extensions` and `num_files` parameters from `BaseBackend.get_file_list()` and all three backends (Local, S3, Azure)
- Backends now return complete, unsorted file listings — `get_file_list()` stays a fast string-path method
- Added `BaseReader._filter_and_limit()` that applies extension filtering, sorting, and `num_files` limiting centrally in the reader
- Removed backend-level tests for extension filtering, num_files limits, and sorting
- Updated remaining backend tests to use set comparisons (order no longer guaranteed)

Refs: #394