### PR TITLE
Add RandomCompose transform

### DIFF
--- a/src/pythermondt/__init__.py
+++ b/src/pythermondt/__init__.py
@@ -6,7 +6,7 @@ from .data import DataContainer, ThermoContainer
 from .dataset import IndexedThermoDataset, ThermoDataset
 from .io import HDF5Parser, SimulationParser
 from .readers import AzureBlobReader, LocalReader, S3Reader
-from .transforms import augmentation, frequency, normalization, preprocessing, sampling, utils
+from .transforms import augmentation, compose, frequency, normalization, preprocessing, sampling, utils
 from .writers import AzureBlobWriter, LocalWriter, S3Writer
 
 # Set up logging per Python best practices: https://docs.python.org/3/howto/logging.html
@@ -28,6 +28,7 @@ __all__ = [
     "ThermoDataset",
     "__version__",
     "augmentation",
+    "compose",
     "configure_logging",
     "frequency",
     "normalization",

--- a/src/pythermondt/dataset/base_dataset.py
+++ b/src/pythermondt/dataset/base_dataset.py
@@ -14,7 +14,9 @@ from tqdm.auto import tqdm
 from ..config import settings
 from ..data import DataContainer
 from ..data.datacontainer.utils import format_bytes
-from ..transforms.utils import Compose, _BaseTransform, _flatten_transforms, split_transforms_for_caching
+from ..transforms.base import _BaseTransform
+from ..transforms.compose import Compose
+from ..transforms.utils import _flatten_transforms, split_transforms_for_caching
 
 CacheMode = Literal["immediate", "lazy"]
 

--- a/src/pythermondt/dataset/thermo_dataset.py
+++ b/src/pythermondt/dataset/thermo_dataset.py
@@ -5,7 +5,7 @@ import torch
 
 from ..data import DataContainer
 from ..readers.base_reader import BaseReader
-from ..transforms.utils import _BaseTransform
+from ..transforms.base import _BaseTransform
 from .base_dataset import BaseDataset
 
 

--- a/src/pythermondt/transforms/__init__.py
+++ b/src/pythermondt/transforms/__init__.py
@@ -1,10 +1,11 @@
 from .augmentation import AdaptiveGaussianNoise, GaussianNoise, RandomFlip
 from .base import RandomThermoTransform, ThermoTransform
+from .compose import Compose
 from .frequency import ExtractAmplitude, ExtractPhase, PulsePhaseThermography
 from .normalization import MaxNormalize, MinMaxNormalize, ZScoreNormalize
 from .preprocessing import ApplyLUT, CropFrames, RemoveFlash, SubtractFrame
 from .sampling import NonUniformSampling, SelectFrameRange, SelectFrames
-from .utils import CallbackTransform, Compose
+from .utils import CallbackTransform
 
 __all__ = [  # noqa: RUF022
     # Base classes

--- a/src/pythermondt/transforms/__init__.py
+++ b/src/pythermondt/transforms/__init__.py
@@ -1,6 +1,6 @@
 from .augmentation import AdaptiveGaussianNoise, GaussianNoise, RandomFlip
 from .base import RandomThermoTransform, ThermoTransform
-from .compose import Compose
+from .compose import Compose, RandomCompose
 from .frequency import ExtractAmplitude, ExtractPhase, PulsePhaseThermography
 from .normalization import MaxNormalize, MinMaxNormalize, ZScoreNormalize
 from .preprocessing import ApplyLUT, CropFrames, RemoveFlash, SubtractFrame
@@ -29,6 +29,7 @@ __all__ = [  # noqa: RUF022
     "ExtractPhase",
     "ExtractAmplitude",
     # Stochastic transforms
+    "RandomCompose",
     "GaussianNoise",
     "RandomFlip",
     "AdaptiveGaussianNoise",

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -7,26 +7,31 @@ from .base import RandomThermoTransform, ThermoTransform, _BaseTransform
 
 
 class Compose(ThermoTransform):
+    # fmt: off
     """Compose a sequence of transforms together into a single transform by applying them sequentially.
 
     Each transform is applied in the order provided to the constructor.
 
     Example:
-        >>> train_pipeline = T.Compose(
-        ...     [
-        ...         T.ApplyLUT(),
-        ...         T.RemoveFlash(),
-        ...         T.SubtractFrame(0),
-        ...         T.MinMaxNormalize(),
-        ...     ]
-        ... )
+        >>> train_pipeline = T.Compose([
+        ...     T.ApplyLUT(),
+        ...     T.SubtractFrame(0),
+        ...     T.RemoveFlash(method='excitation_signal'),
+        ...     T.NonUniformSampling(64),
+        ...     T.RandomFlip(p_height=0.3, p_width=0.3),
+        ...     T.GaussianNoise(std=25e-3),
+        ...     T.MinMaxNormalize(),
+        ... ])
     """
-
+    # fmt: on
     def __init__(self, transforms: Sequence[_BaseTransform]):
-        """Compose a sequence of transforms together into a single transform by applying them sequentially.
+        """Initialize the Compose transform.
 
         Args:
             transforms (Sequence[_BaseTransform]): List of transforms to apply sequentially.
+
+        Raises:
+            TypeError: If not all transforms inherit from _BaseTransform.
         """
         super().__init__()
 
@@ -56,6 +61,7 @@ class Compose(ThermoTransform):
 
 
 class RandomCompose(RandomThermoTransform):
+    # fmt: off
     """Apply each transform independently with probability p.
 
     Unlike Compose (which applies all transforms sequentially),
@@ -63,26 +69,20 @@ class RandomCompose(RandomThermoTransform):
 
     Example:
         >>> # Each augmentation applied independently with 30% chance
-        >>> augmentation_pipeline = T.RandomCompose(
-        ...     [
-        ...         T.AdaptiveGaussianNoise(),
-        ...         T.RandomFlip(),
-        ...     ],
-        ...     p=0.3,
-        ... )
+        >>> augmentations = T.RandomCompose([
+        ...     T.AdaptiveGaussianNoise(),
+        ...     T.RandomFlip(),
+        ... ], p=0.3)
 
         >>> # Different probabilities per transform
-        >>> augmentation_pipeline = T.RandomCompose(
-        ...     [
-        ...         T.AdaptiveGaussianNoise(),
-        ...         T.RandomFlip(),
-        ...     ],
-        ...     p=[0.5, 0.2],
-        ... )
+        >>> augmentations = T.RandomCompose([
+        ...     T.AdaptiveGaussianNoise(),
+        ...     T.RandomFlip(),
+        ... ], p=[0.5, 0.2])
     """
-
+    # fmt: on
     def __init__(self, transforms: Sequence[_BaseTransform], p: float | Sequence[float] = 0.5):
-        """Apply each transform independently with probability p.
+        """Initialize the RandomCompose transform.
 
         Args:
             transforms (Sequence[_BaseTransform]): List of transforms to apply randomly.

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -94,6 +94,20 @@ class RandomCompose(RandomThermoTransform):
                 raise ValueError(f"Length of p ({len(p)}) must match transforms ({len(transforms)})")
             self.probs = [float(pi) for pi in p]
 
+    def __str__(self) -> str:
+        """Custom repr for RandomCompose - no type label, cleaner format."""
+        if not self.transforms:
+            return "RandomCompose([])"
+
+        # Show transforms in a clean format with probabilities
+        transform_strs = [f"{t} (p={p:.2f})" for t, p in zip(self.transforms, self.probs, strict=True)]
+        if len(transform_strs) == 1:
+            return f"RandomCompose([{transform_strs[0]}])"
+
+        # Multi-line format for multiple transforms
+        transforms_str = ",\n    ".join(transform_strs)
+        return f"RandomCompose([\n    {transforms_str}\n])"
+
     def forward(self, container: DataContainer) -> DataContainer:
         for transform, prob in zip(self.transforms, self.probs, strict=True):
             if torch.rand(1).item() < prob:

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -109,11 +109,11 @@ class RandomCompose(RandomThermoTransform):
 
         # Handle scalar or list of probabilities
         if isinstance(p, (int, float)):
-            self.probs = [float(p)] * len(transforms)
+            self.p = [float(p)] * len(transforms)
         else:
             if len(p) != len(transforms):
                 raise ValueError(f"Length of p ({len(p)}) must match transforms ({len(transforms)}).")
-            self.probs = [float(pi) for pi in p]
+            self.p = [float(pi) for pi in p]
 
     def __str__(self) -> str:
         """Custom repr for RandomCompose - no type label, cleaner format."""

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -7,15 +7,26 @@ from .base import RandomThermoTransform, ThermoTransform, _BaseTransform
 
 
 class Compose(ThermoTransform):
-    """Compose a sequence of transforms together into a single transform.
+    """Compose a sequence of transforms together into a single transform by applying them sequentially.
 
-    This transform sequentially applies a list of transforms to the input container.
+    Each transform is applied in the order provided to the constructor.
+
+    Example:
+        >>> train_pipeline = T.Compose(
+        ...     [
+        ...         T.ApplyLUT(),
+        ...         T.RemoveFlash(),
+        ...         T.SubtractFrame(0),
+        ...         T.MinMaxNormalize(),
+        ...     ]
+        ... )
     """
 
     def __init__(self, transforms: Sequence[_BaseTransform]):
-        """Compose a sequence of transforms together into a single transform.
+        """Compose a sequence of transforms together into a single transform by applying them sequentially.
 
-        This transform sequentially applies a list of transforms to the input container.
+        Args:
+            transforms (Sequence[_BaseTransform]): List of transforms to apply sequentially.
         """
         super().__init__()
 
@@ -49,11 +60,6 @@ class RandomCompose(RandomThermoTransform):
 
     Unlike Compose (which applies all transforms sequentially),
     RandomCompose applies each transform with probability p.
-
-    Args:
-        transforms: List of transforms to apply randomly.
-        p: Probability for each transform. Scalar (same for all) or
-           list of probabilities (one per transform). Default: 0.5
 
     Example:
         >>> # Each augmentation applied independently with 30% chance

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -77,12 +77,12 @@ class RandomCompose(RandomThermoTransform):
         ...         T.AdaptiveGaussianNoise(),
         ...         T.RandomFlip(),
         ...     ],
-        ...     p=0.3,
+        ...     p=[0.5, 0.2],
         ... )
     """
 
     def __init__(self, transforms: Sequence[_BaseTransform], p: float | Sequence[float] = 0.5):
-        """Compose a sequence of transforms together into a single transform, applying each with probability p.
+        """Apply each transform independently with probability p.
 
         Args:
             transforms (Sequence[_BaseTransform]): List of transforms to apply randomly.

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -6,6 +6,14 @@ from ..data import DataContainer
 from .base import RandomThermoTransform, ThermoTransform, _BaseTransform
 
 
+def _indent_str(s: str, indent: str = "    ") -> str:
+    """Indent all lines after the first of a multi-line string."""
+    if "\n" not in s:
+        return s
+    lines = s.split("\n")
+    return "\n".join([lines[0]] + [indent + line for line in lines[1:]])
+
+
 class Compose(ThermoTransform):
     # fmt: off
     """Compose a sequence of transforms together into a single transform by applying them sequentially.
@@ -45,8 +53,8 @@ class Compose(ThermoTransform):
         if not self.transforms:
             return "Compose([])"
 
-        # Show transforms in a clean format
-        transform_strs = [str(t) for t in self.transforms]
+        # Show transforms in a clean format, indent nested containers
+        transform_strs = [_indent_str(str(t)) for t in self.transforms]
         if len(transform_strs) == 1:
             return f"Compose([{transform_strs[0]}])"
 
@@ -112,8 +120,8 @@ class RandomCompose(RandomThermoTransform):
         if not self.transforms:
             return "RandomCompose([])"
 
-        # Show transforms in a clean format with probabilities
-        transform_strs = [f"{t} (p={p:.2f})" for t, p in zip(self.transforms, self.probs, strict=True)]
+        # Show transforms in a clean format with probabilities, indent nested containers
+        transform_strs = [_indent_str(f"{t} (p={p:.2f})") for t, p in zip(self.transforms, self.probs, strict=True)]
         if len(transform_strs) == 1:
             return f"RandomCompose([{transform_strs[0]}])"
 

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -115,13 +115,17 @@ class RandomCompose(RandomThermoTransform):
                 raise ValueError(f"Length of p ({len(p)}) must match transforms ({len(transforms)}).")
             self.p = [float(pi) for pi in p]
 
+        # Validate range
+        if not all(0 <= prob <= 1 for prob in self.p):
+            raise ValueError(f"All probabilities must be in [0, 1], got {self.p}.")
+
     def __str__(self) -> str:
         """Custom repr for RandomCompose - no type label, cleaner format."""
         if not self.transforms:
             return "RandomCompose([])"
 
         # Show transforms in a clean format with probabilities, indent nested containers
-        transform_strs = [_indent_str(f"{t} (p={p:.2f})") for t, p in zip(self.transforms, self.probs, strict=True)]
+        transform_strs = [_indent_str(f"{t} (p={p:.2f})") for t, p in zip(self.transforms, self.p, strict=True)]
         if len(transform_strs) == 1:
             return f"RandomCompose([{transform_strs[0]}])"
 
@@ -130,7 +134,7 @@ class RandomCompose(RandomThermoTransform):
         return f"RandomCompose([\n    {transforms_str}\n])"
 
     def forward(self, container: DataContainer) -> DataContainer:
-        for transform, prob in zip(self.transforms, self.probs, strict=True):
+        for transform, prob in zip(self.transforms, self.p, strict=True):
             if torch.rand(1).item() < prob:
                 container = transform(container)
         return container

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -1,7 +1,9 @@
 from collections.abc import Sequence
 
+import torch
+
 from ..data import DataContainer
-from .base import ThermoTransform, _BaseTransform
+from .base import RandomThermoTransform, ThermoTransform, _BaseTransform
 
 
 class Compose(ThermoTransform):
@@ -39,4 +41,61 @@ class Compose(ThermoTransform):
     def forward(self, container: DataContainer) -> DataContainer:
         for t in self.transforms:
             container = t(container)
+        return container
+
+
+class RandomCompose(RandomThermoTransform):
+    """Apply each transform independently with probability p.
+
+    Unlike Compose (which applies all transforms sequentially),
+    RandomCompose applies each transform with probability p.
+
+    Args:
+        transforms: List of transforms to apply randomly.
+        p: Probability for each transform. Scalar (same for all) or
+           list of probabilities (one per transform). Default: 0.5
+
+    Example:
+        >>> # Each augmentation applied independently with 30% chance
+        >>> augmentation_pipeline = T.RandomCompose(
+        ...     [
+        ...         T.AdaptiveGaussianNoise(),
+        ...         T.RandomFlip(),
+        ...     ],
+        ...     p=0.3,
+        ... )
+
+        >>> # Different probabilities per transform
+        >>> augmentation_pipeline = T.RandomCompose(
+        ...     [
+        ...         T.AdaptiveGaussianNoise(),
+        ...         T.RandomFlip(),
+        ...     ],
+        ...     p=0.3,
+        ... )
+    """
+
+    def __init__(self, transforms: Sequence[_BaseTransform], p: float | Sequence[float] = 0.5):
+        """Compose a sequence of transforms together into a single transform, applying each with probability p.
+
+        Args:
+            transforms (Sequence[_BaseTransform]): List of transforms to apply randomly.
+            p (float | Sequence[float]): Probability for each transform. Can either be a scalar (same for all) or
+                sequence of probabilities (one per transform). Default: 0.5
+        """
+        super().__init__()
+        self.transforms = transforms
+
+        # Handle scalar or list of probabilities
+        if isinstance(p, (int, float)):
+            self.probs = [float(p)] * len(transforms)
+        else:
+            if len(p) != len(transforms):
+                raise ValueError(f"Length of p ({len(p)}) must match transforms ({len(transforms)})")
+            self.probs = [float(pi) for pi in p]
+
+    def forward(self, container: DataContainer) -> DataContainer:
+        for transform, prob in zip(self.transforms, self.probs, strict=True):
+            if torch.rand(1).item() < prob:
+                container = transform(container)
         return container

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -1,0 +1,42 @@
+from collections.abc import Sequence
+
+from ..data import DataContainer
+from .base import ThermoTransform, _BaseTransform
+
+
+class Compose(ThermoTransform):
+    """Compose a sequence of transforms together into a single transform.
+
+    This transform sequentially applies a list of transforms to the input container.
+    """
+
+    def __init__(self, transforms: Sequence[_BaseTransform]):
+        """Compose a sequence of transforms together into a single transform.
+
+        This transform sequentially applies a list of transforms to the input container.
+        """
+        super().__init__()
+
+        # Check if all the provided transforms are valid (Thermotransforms are already callable)
+        if not all(isinstance(t, _BaseTransform) for t in transforms):
+            raise TypeError("Not all transforms inherit from _BaseTransform.")
+        self.transforms = transforms
+
+    def __str__(self) -> str:
+        """Custom repr for Compose - no type label, cleaner format."""
+        if not self.transforms:
+            return "Compose([])"
+
+        # Show transforms in a clean format
+        transform_strs = [str(t) for t in self.transforms]
+        if len(transform_strs) == 1:
+            return f"Compose([{transform_strs[0]}])"
+
+        # Multi-line format for multiple transforms
+        transforms_str = ",\n    ".join(transform_strs)
+        return f"Compose([\n    {transforms_str}\n])"
+
+    def forward(self, container: DataContainer) -> DataContainer:
+        for t in self.transforms:
+            container = t(container)
+        return container

--- a/src/pythermondt/transforms/compose.py
+++ b/src/pythermondt/transforms/compose.py
@@ -88,8 +88,15 @@ class RandomCompose(RandomThermoTransform):
             transforms (Sequence[_BaseTransform]): List of transforms to apply randomly.
             p (float | Sequence[float]): Probability for each transform. Can either be a scalar (same for all) or
                 sequence of probabilities (one per transform). Default: 0.5
+
+        Raises:
+            TypeError: If not all transforms inherit from _BaseTransform.
+            ValueError: If p is a sequence and its length doesn't match transforms.
         """
         super().__init__()
+
+        if not all(isinstance(t, _BaseTransform) for t in transforms):
+            raise TypeError("Not all transforms inherit from _BaseTransform.")
         self.transforms = transforms
 
         # Handle scalar or list of probabilities
@@ -97,7 +104,7 @@ class RandomCompose(RandomThermoTransform):
             self.probs = [float(p)] * len(transforms)
         else:
             if len(p) != len(transforms):
-                raise ValueError(f"Length of p ({len(p)}) must match transforms ({len(transforms)})")
+                raise ValueError(f"Length of p ({len(p)}) must match transforms ({len(transforms)}).")
             self.probs = [float(pi) for pi in p]
 
     def __str__(self) -> str:

--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -1,45 +1,8 @@
 from collections.abc import Callable, Sequence
 
 from ..data import DataContainer
-from .base import ThermoTransform, _BaseTransform
-
-
-class Compose(ThermoTransform):
-    """Compose a sequence of transforms together into a single transform.
-
-    This transform sequentially applies a list of transforms to the input container.
-    """
-
-    def __init__(self, transforms: Sequence[_BaseTransform]):
-        """Compose a sequence of transforms together into a single transform.
-
-        This transform sequentially applies a list of transforms to the input container.
-        """
-        super().__init__()
-
-        # Check if all the provided transforms are valid (Thermotransforms are already callable)
-        if not all(isinstance(t, _BaseTransform) for t in transforms):
-            raise TypeError("Not all transforms inherit from _BaseTransform.")
-        self.transforms = transforms
-
-    def __str__(self) -> str:
-        """Custom repr for Compose - no type label, cleaner format."""
-        if not self.transforms:
-            return "Compose([])"
-
-        # Show transforms in a clean format
-        transform_strs = [str(t) for t in self.transforms]
-        if len(transform_strs) == 1:
-            return f"Compose([{transform_strs[0]}])"
-
-        # Multi-line format for multiple transforms
-        transforms_str = ",\n    ".join(transform_strs)
-        return f"Compose([\n    {transforms_str}\n])"
-
-    def forward(self, container: DataContainer) -> DataContainer:
-        for t in self.transforms:
-            container = t(container)
-        return container
+from .base import _BaseTransform
+from .compose import Compose
 
 
 class CallbackTransform(_BaseTransform):


### PR DESCRIPTION
- Extract `Compose` from `transforms/utils.py` into a new `transforms/compose.py` module with improved docstrings and nested-container indentation in `__str__`
- Add `RandomCompose(RandomThermoTransform)` that applies each contained transform independently with a configurable probability `p` — supports a single scalar (same for all) or a per-transform sequence
- Validate probability values are in `[0, 1]` and raise `ValueError` on out-of-range input
- Update all imports (`transforms/__init__.py`, `base_dataset.py`, `thermo_dataset.py`, `utils.py`, package `__init__.py`) to point to the new module locations without breaking backward compatibility

New `RandomCompose` enables stochastic augmentation pipelines where each transform is applied independently with a given probability, complementing the existing deterministic `Compose`.