### PR TITLE
Add CastTo transform for dtype casting of container datasets

### DIFF
--- a/src/pythermondt/transforms/__init__.py
+++ b/src/pythermondt/transforms/__init__.py
@@ -3,7 +3,7 @@ from .base import RandomThermoTransform, ThermoTransform
 from .compose import Compose, RandomCompose
 from .frequency import ExtractAmplitude, ExtractPhase, PulsePhaseThermography
 from .normalization import MaxNormalize, MinMaxNormalize, ZScoreNormalize
-from .preprocessing import ApplyLUT, CropFrames, RemoveFlash, SubtractFrame
+from .preprocessing import ApplyLUT, CastTo, CropFrames, RemoveFlash, SubtractFrame
 from .sampling import NonUniformSampling, SelectFrameRange, SelectFrames
 from .utils import CallbackTransform
 
@@ -19,6 +19,7 @@ __all__ = [  # noqa: RUF022
     "MinMaxNormalize",
     "ZScoreNormalize",
     "ApplyLUT",
+    "CastTo",
     "RemoveFlash",
     "SubtractFrame",
     "NonUniformSampling",

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -110,7 +110,7 @@ class CastTo(ThermoTransform):
         tensors = container.get_datasets(*self.datasets)
 
         # Cast each tensor to its target dtype
-        updates = ((p, t.to(dtype)) for p, t, dtype in zip(self.datasets, tensors, self.dtype, strict=True))
+        updates = ((p, t.to(dt)) for p, t, dt in zip(self.datasets, tensors, self.dtype, strict=True))
 
         # Update the container and return it
         container.update_datasets(*updates)

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import Literal, get_args
 
 import torch
@@ -56,6 +57,63 @@ class ApplyLUT(ThermoTransform):
         # Update the container and return it
         container.update_dataset("/Data/Tdata", tdata)
         container.update_unit("/Data/Tdata", kelvin)
+        return container
+
+
+class CastTo(ThermoTransform):
+    """Cast one or more datasets in the container to a specified torch dtype.
+
+    ``datasets`` may be a single path or a sequence of paths. A single dtype is applied to all datasets;
+    alternatively, a sequence of dtypes (one per dataset) allows casting different datasets to different dtypes.
+    """
+
+    def __init__(self, datasets: str | Sequence[str], dtype: torch.dtype | Sequence[torch.dtype]):
+        """Cast one or more datasets in the container to a specified torch dtype.
+
+        A single dtype is applied to all datasets; alternatively, a sequence of dtypes (one per dataset) allows
+        casting different datasets to different dtypes.
+
+        Args:
+            datasets (str | Sequence[str]): Dataset path or sequence of paths to cast. Must be non-empty.
+            dtype (torch.dtype | Sequence[torch.dtype]): Target torch dtype, either a single dtype applied to
+                all datasets or a sequence with one dtype per dataset.
+
+        Raises:
+            TypeError: If ``dtype`` is not a ``torch.dtype`` or a sequence of ``torch.dtype``.
+            ValueError: If ``datasets`` is empty or the number of dtypes does not match the number of datasets.
+        """
+        super().__init__()
+
+        # Normalize datasets to a list (str is a Sequence, so check it first to avoid splitting the path)
+        datasets = [datasets] if isinstance(datasets, str) else list(datasets)
+        if not datasets:
+            raise ValueError("datasets must be a non-empty sequence of dataset paths.")
+
+        # Normalize dtype to a per-dataset list
+        if isinstance(dtype, torch.dtype):
+            dtypes = [dtype] * len(datasets)
+        elif isinstance(dtype, Sequence):
+            dtypes = list(dtype)
+        else:
+            raise TypeError(f"dtype must be a torch.dtype or a sequence of torch.dtype, got {type(dtype).__name__}.")
+
+        if len(dtypes) != len(datasets):
+            raise ValueError(f"Number of dtypes ({len(dtypes)}) must match number of datasets ({len(datasets)}).")
+        if not all(isinstance(d, torch.dtype) for d in dtypes):
+            raise TypeError("All dtypes must be torch.dtype instances.")
+
+        self.datasets = datasets
+        self.dtype = dtypes
+
+    def forward(self, container: DataContainer) -> DataContainer:
+        # Extract the datasets
+        tensors = container.get_datasets(*self.datasets)
+
+        # Cast each tensor to its target dtype
+        updates = ((p, t.to(dtype)) for p, t, dtype in zip(self.datasets, tensors, self.dtype, strict=True))
+
+        # Update the container and return it
+        container.update_datasets(*updates)
         return container
 
 


### PR DESCRIPTION
- Add `CastTo` transform that casts one or more datasets in a `DataContainer` to specified torch dtypes
- Support single or per-dataset dtype specification with input validation
- Register `CastTo` in `transforms/__init__.py` public API
- Fix scope of `dtype` variable to prevent reference before assignment

CastTo provides a flexible, validated way to change tensor dtypes in thermal data pipelines, accepting either a single dtype for all targeted datasets or a sequence of dtypes for per-dataset control.