### PR TITLE
Fix empty reader detection for mixed reader types in ThermoDataset

### DIFF
--- a/src/pythermondt/dataset/thermo_dataset.py
+++ b/src/pythermondt/dataset/thermo_dataset.py
@@ -101,7 +101,7 @@ class ThermoDataset(BaseDataset):
 
             # Else duplicates are not possible ==> Check if the reader has found any files
             else:
-                if len(readers[0].files) == 0:
+                if len(readers_objects[0].files) == 0:
                     warnings.warn(f"No files found for reader of type {reader_type.__qualname__}", stacklevel=2)
 
     def _build_index(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@ from pythermondt import DataContainer, LocalReader, S3Reader
 from pythermondt.transforms import Compose, RandomThermoTransform, ThermoTransform
 
 
+class AltReader(LocalReader):
+    """LocalReader subclass used in tests to simulate a different reader type."""
+
+
 @pytest.fixture()
 def fake_aws_creds(monkeypatch):
     """Mocked AWS Credentials for moto."""
@@ -77,6 +81,12 @@ def sample_eye_ndarray():
 def localreader_no_files():
     """Fixture for a reader that has no files."""
     return LocalReader(pattern="MadeUpPattern")
+
+
+@pytest.fixture
+def altreader_no_files():
+    """Fixture for an AltReader that has no files."""
+    return AltReader(pattern="MadeUpPattern")
 
 
 @pytest.fixture

--- a/tests/dataset/test_thermo_dataset.py
+++ b/tests/dataset/test_thermo_dataset.py
@@ -158,6 +158,28 @@ def test_empty_reader_in_multi_reader_warns(localreader_with_file: LocalReader, 
         ThermoDataset([localreader_no_files, localreader_with_file])
 
 
+def test_empty_reader_different_type_warns(localreader_with_file: LocalReader, altreader_no_files: LocalReader):
+    """Test that an empty reader of a different type is detected regardless of its position.
+
+    Regression test for issue #425: the else branch of _validate_readers incorrectly checked
+    readers[0] instead of readers_objects[0], so empty readers of a different type than the
+    first reader were silently missed.
+    """
+    expected_match = r"No files found for reader of type .*AltReader"
+
+    # Empty reader NOT first — must still warn (this was the swallowed-warning case)
+    with pytest.warns(UserWarning, match=expected_match):
+        ThermoDataset([localreader_with_file, altreader_no_files])
+
+    # Empty reader first — must warn and NOT produce a false positive for the other type
+    with pytest.warns(UserWarning, match=expected_match) as record:
+        ThermoDataset([altreader_no_files, localreader_with_file])
+    messages = [str(w.message) for w in record]
+    assert not any("LocalReader" in m for m in messages), (
+        f"False positive warning for non-empty reader type: {messages}"
+    )
+
+
 def test_download_delegates_to_readers(s3reader_with_file: S3Reader, localreader_with_file: LocalReader):
     """Test that dataset.download() calls download on remote readers."""
     # Expect warning because fixture has download_files=False for the S3 reader


### PR DESCRIPTION
- Fixed `_validate_readers` in `ThermoDataset`: the else branch for single-reader-of-a-type checked `readers[0]` (first reader in the full list) instead of `readers_objects[0]` (the actual reader of that type), causing empty readers of a different type to be silently missed
- Added `AltReader(LocalReader)` test class and `altreader_no_files` fixture to `conftest.py` for reusable cross-type testing
- Added `test_empty_reader_different_type_warns` regression test verifying the empty-reader warning is emitted regardless of the reader's position in the list and that non-empty readers don't produce false positive warnings

Closes #425