### PR TITLE
Fix CropFrames and RandomFlip crash when container lacks GroundTruth

### DIFF
--- a/src/pythermondt/transforms/augmentation.py
+++ b/src/pythermondt/transforms/augmentation.py
@@ -2,6 +2,7 @@ import torch
 
 from ..data import DataContainer
 from .base import RandomThermoTransform
+from .utils import _get_optional_dataset
 
 
 class RandomFlip(RandomThermoTransform):
@@ -37,21 +38,27 @@ class RandomFlip(RandomThermoTransform):
         self.p_width = p_width
 
     def forward(self, container: DataContainer) -> DataContainer:
-        # Extract the data
-        tdata, mask = container.get_datasets("/Data/Tdata", "/GroundTruth/DefectMask")
+        # Extract the data (DefectMask is optional)
+        tdata = container.get_dataset("/Data/Tdata")
+        has_mask, mask = _get_optional_dataset(container, "/GroundTruth/DefectMask")
 
         # Flip the data along the height if the random number is less than p_height
         if torch.rand(1).item() < self.p_height:
             tdata = torch.flip(tdata, [1])
-            mask = torch.flip(mask, [1])
+            if has_mask:
+                mask = torch.flip(mask, [1])  # type: ignore[arg-type]
 
         # Flip the data along the width if the random number is less than p_width
         if torch.rand(1).item() < self.p_width:
             tdata = torch.flip(tdata, [0])
-            mask = torch.flip(mask, [0])
+            if has_mask:
+                mask = torch.flip(mask, [0])  # type: ignore[arg-type]
 
         # Update the container and return it
-        container.update_datasets(("/Data/Tdata", tdata), ("/GroundTruth/DefectMask", mask))
+        updates: list[tuple[str, torch.Tensor]] = [("/Data/Tdata", tdata)]
+        if has_mask:
+            updates.append(("/GroundTruth/DefectMask", mask))  # type: ignore[arg-type]
+        container.update_datasets(*updates)
         return container
 
 

--- a/src/pythermondt/transforms/augmentation.py
+++ b/src/pythermondt/transforms/augmentation.py
@@ -40,24 +40,24 @@ class RandomFlip(RandomThermoTransform):
     def forward(self, container: DataContainer) -> DataContainer:
         # Extract the data (DefectMask is optional)
         tdata = container.get_dataset("/Data/Tdata")
-        has_mask, mask = _get_optional_dataset(container, "/GroundTruth/DefectMask")
+        _, mask = _get_optional_dataset(container, "/GroundTruth/DefectMask")
 
         # Flip the data along the height if the random number is less than p_height
         if torch.rand(1).item() < self.p_height:
             tdata = torch.flip(tdata, [1])
-            if has_mask:
-                mask = torch.flip(mask, [1])  # type: ignore[arg-type]
+            if mask:
+                mask = torch.flip(mask, [1])
 
         # Flip the data along the width if the random number is less than p_width
         if torch.rand(1).item() < self.p_width:
             tdata = torch.flip(tdata, [0])
-            if has_mask:
-                mask = torch.flip(mask, [0])  # type: ignore[arg-type]
+            if mask:
+                mask = torch.flip(mask, [0])
 
         # Update the container and return it
         updates: list[tuple[str, torch.Tensor]] = [("/Data/Tdata", tdata)]
-        if has_mask:
-            updates.append(("/GroundTruth/DefectMask", mask))  # type: ignore[arg-type]
+        if mask:
+            updates.append(("/GroundTruth/DefectMask", mask))
         container.update_datasets(*updates)
         return container
 

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -274,10 +274,10 @@ class CropFrames(ThermoTransform):
         self.width = width
         self.strategy = method
 
-    def forward(self, container: DataContainer) -> DataContainer:
+    def forward(self, container: DataContainer) -> DataContainer:  # pylint: disable=too-many-branches
         # Extract the data (DefectMask is optional)
         tdata = container.get_dataset("/Data/Tdata")
-        has_mask, mask = _get_optional_dataset(container, "/GroundTruth/DefectMask")
+        _, mask = _get_optional_dataset(container, "/GroundTruth/DefectMask")
 
         if self.height > tdata.shape[0]:
             raise ValueError(
@@ -352,8 +352,8 @@ class CropFrames(ThermoTransform):
 
         # Build update tuples (only include mask if present and non-empty)
         updates: list[tuple[str, torch.Tensor]] = [("/Data/Tdata", tdata)]
-        if has_mask:
-            mask = mask[top:bottom, left:right]  # type: ignore[index]
+        if mask:
+            mask = mask[top:bottom, left:right]
             updates.append(("/GroundTruth/DefectMask", mask))
 
         container.update_datasets(*updates)

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -274,8 +274,13 @@ class CropFrames(ThermoTransform):
         self.strategy = method
 
     def forward(self, container: DataContainer) -> DataContainer:
-        # Extract the data
-        tdata, mask = container.get_datasets("/Data/Tdata", "/GroundTruth/DefectMask")
+        # Extract the data (DefectMask is optional)
+        tdata = container.get_dataset("/Data/Tdata")
+        mask = None
+
+        # TODO: Simplify this check once https://github.com/voidsy-gmbh/pyThermoNDT/issues/420 is resolved
+        mask_path = "/GroundTruth/DefectMask"
+        has_mask = container._is_datanode(mask_path) and (mask := container.get_dataset(mask_path)).numel() > 0
 
         if self.height > tdata.shape[0]:
             raise ValueError(
@@ -347,8 +352,12 @@ class CropFrames(ThermoTransform):
 
         # Crop the data
         tdata = tdata[top:bottom, left:right]
-        mask = mask[top:bottom, left:right]
 
-        # Update the container and return it
-        container.update_datasets(("/Data/Tdata", tdata), ("/GroundTruth/DefectMask", mask))
+        # Build update tuples (only include mask if present and non-empty)
+        updates = [("/Data/Tdata", tdata)]
+        if has_mask and mask:
+            mask = mask[top:bottom, left:right]
+            updates.append((mask_path, mask))
+
+        container.update_datasets(*updates)
         return container

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -6,6 +6,7 @@ import torch
 from ..data import DataContainer
 from ..data.units import arbitrary, kelvin
 from .base import ThermoTransform
+from .utils import _get_optional_dataset
 
 
 class ApplyLUT(ThermoTransform):
@@ -276,11 +277,7 @@ class CropFrames(ThermoTransform):
     def forward(self, container: DataContainer) -> DataContainer:
         # Extract the data (DefectMask is optional)
         tdata = container.get_dataset("/Data/Tdata")
-        mask = None
-
-        # TODO: Simplify this check once https://github.com/voidsy-gmbh/pyThermoNDT/issues/420 is resolved
-        mask_path = "/GroundTruth/DefectMask"
-        has_mask = container._is_datanode(mask_path) and (mask := container.get_dataset(mask_path)).numel() > 0
+        has_mask, mask = _get_optional_dataset(container, "/GroundTruth/DefectMask")
 
         if self.height > tdata.shape[0]:
             raise ValueError(
@@ -354,10 +351,10 @@ class CropFrames(ThermoTransform):
         tdata = tdata[top:bottom, left:right]
 
         # Build update tuples (only include mask if present and non-empty)
-        updates = [("/Data/Tdata", tdata)]
-        if has_mask and mask:
-            mask = mask[top:bottom, left:right]
-            updates.append((mask_path, mask))
+        updates: list[tuple[str, torch.Tensor]] = [("/Data/Tdata", tdata)]
+        if has_mask:
+            mask = mask[top:bottom, left:right]  # type: ignore[index]
+            updates.append(("/GroundTruth/DefectMask", mask))
 
         container.update_datasets(*updates)
         return container

--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable, Sequence
 
+from torch import Tensor
+
 from ..data import DataContainer
 from .base import _BaseTransform
 from .compose import Compose
@@ -113,3 +115,24 @@ def _flatten_transforms(transforms: Sequence[_BaseTransform]) -> Sequence[_BaseT
         else:
             flattened.append(transform)
     return flattened
+
+
+def _get_optional_dataset(container: DataContainer, path: str) -> tuple[bool, Tensor | None]:
+    """Return whether a dataset exists and is non-empty, along with its tensor.
+
+    Handles two cases where the dataset should be treated as absent:
+    - No node at ``path``.
+    - A ``torch.empty(0)`` sentinel (see linked issue).
+
+    Args:
+        container: The DataContainer to probe.
+        path: Full path to the dataset (e.g. ``"/GroundTruth/DefectMask"``).
+
+    Returns:
+        A tuple ``(exists, tensor)``.  ``exists`` is ``True`` only when the
+        dataset is present and non-empty; ``tensor`` is the dataset or ``None``.
+    """
+    # TODO: Simplify this check once https://github.com/voidsy-gmbh/pyThermoNDT/issues/420 is resolved
+    dataset = None
+    has_dataset = container._is_datanode(path) and (dataset := container.get_dataset(path)).numel() > 0
+    return has_dataset, dataset

--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -135,4 +135,4 @@ def _get_optional_dataset(container: DataContainer, path: str) -> tuple[bool, Te
     # TODO: Simplify this check once https://github.com/voidsy-gmbh/pyThermoNDT/issues/420 is resolved
     dataset = None
     has_dataset = container._is_datanode(path) and (dataset := container.get_dataset(path)).numel() > 0
-    return has_dataset, dataset
+    return has_dataset, dataset if has_dataset else None

--- a/src/pythermondt/transforms/utils.py
+++ b/src/pythermondt/transforms/utils.py
@@ -134,5 +134,5 @@ def _get_optional_dataset(container: DataContainer, path: str) -> tuple[bool, Te
     """
     # TODO: Simplify this check once https://github.com/voidsy-gmbh/pyThermoNDT/issues/420 is resolved
     dataset = None
-    has_dataset = container._is_datanode(path) and (dataset := container.get_dataset(path)).numel() > 0
+    has_dataset = container._is_datanode(path) and (dataset := container.get_dataset(path)).numel() > 0  # pylint: disable=protected-access
     return has_dataset, dataset if has_dataset else None


### PR DESCRIPTION
- Added `_get_optional_dataset()` helper to `utils.py` that safely probes for a dataset, handling both missing nodes and the `torch.empty(0)` sentinel
- Updated `CropFrames` (`preprocessing.py`) to use the helper so it no longer crashes when a container has no `DefectMask`
- Updated `RandomFlip` (`augmentation.py`) with the same fix — it had the identical bug of unconditionally requiring a mask

Both transforms now treat a missing or empty `DefectMask` as absent and skip mask operations, only updating `Tdata`. Closes #393 