### PR TITLE
Add get_file_list_with_metadata returning FileInfo across all backends

### DIFF
--- a/src/pythermondt/io/__init__.py
+++ b/src/pythermondt/io/__init__.py
@@ -1,4 +1,12 @@
-from .backends import AzureBlobBackend, AzureBlobClientOptions, BaseBackend, LocalBackend, S3Backend, S3ClientOptions
+from .backends import (
+    AzureBlobBackend,
+    AzureBlobClientOptions,
+    BaseBackend,
+    FileInfo,
+    LocalBackend,
+    S3Backend,
+    S3ClientOptions,
+)
 from .parsers import BaseParser, EdevisParser, HDF5Parser, SimulationParser
 from .utils import IOPathWrapper
 
@@ -8,6 +16,7 @@ __all__ = [
     "BaseBackend",
     "BaseParser",
     "EdevisParser",
+    "FileInfo",
     "HDF5Parser",
     "IOPathWrapper",
     "LocalBackend",

--- a/src/pythermondt/io/backends/__init__.py
+++ b/src/pythermondt/io/backends/__init__.py
@@ -1,5 +1,5 @@
 from .azure_backend import AzureBlobBackend
-from .base_backend import BaseBackend
+from .base_backend import BaseBackend, FileInfo
 from .local_backend import LocalBackend
 from .options import AzureBlobClientOptions, S3ClientOptions
 from .s3_backend import S3Backend
@@ -8,6 +8,7 @@ __all__ = [
     "AzureBlobBackend",
     "AzureBlobClientOptions",
     "BaseBackend",
+    "FileInfo",
     "LocalBackend",
     "S3Backend",
     "S3ClientOptions",

--- a/src/pythermondt/io/backends/azure_backend.py
+++ b/src/pythermondt/io/backends/azure_backend.py
@@ -9,7 +9,7 @@ from azure.storage.blob import BlobServiceClient
 from tqdm.auto import tqdm
 
 from ..utils import IOPathWrapper
-from .base_backend import BaseBackend
+from .base_backend import BaseBackend, FileInfo
 from .options import AzureBlobClientOptions
 from .progress import TqdmCallback, get_tqdm_default_kwargs
 
@@ -181,6 +181,30 @@ class AzureBlobBackend(BaseBackend):
             blobs.append(self._to_url(self.__container_name, blob.name))
 
         return blobs
+
+    def get_file_list_with_metadata(self) -> list[FileInfo]:
+        """Return all blobs under the configured prefix as ``FileInfo`` entries (unsorted).
+
+        Metadata (``last_modified``, ``size``, ``etag``) is gathered from the
+        ``list_blobs`` response — no extra HEAD requests.
+        """
+        container_client = self.__client.get_container_client(self.__container_name)
+
+        files = []
+        for blob in container_client.list_blobs(name_starts_with=self.prefix):
+            if blob.name.endswith("/"):
+                continue
+
+            files.append(
+                FileInfo(
+                    path=self._to_url(self.__container_name, blob.name),
+                    last_modified=blob.last_modified,
+                    size=blob.size,
+                    file_identity=str(blob.etag) if blob.etag else None,
+                )
+            )
+
+        return files
 
     def get_file_size(self, file_path: str) -> int:
         """Get the size of the file in Azure Blob Storage in bytes.

--- a/src/pythermondt/io/backends/azure_backend.py
+++ b/src/pythermondt/io/backends/azure_backend.py
@@ -1,11 +1,12 @@
 import logging
+from collections.abc import Generator
 from io import BytesIO
 from typing import IO, cast
 
 from azure.core.credentials import TokenCredential
 from azure.core.exceptions import AzureError, ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobProperties, BlobServiceClient
 from tqdm.auto import tqdm
 
 from ..utils import IOPathWrapper
@@ -168,18 +169,27 @@ class AzureBlobBackend(BaseBackend):
         """
         self.__client.close()
 
+    def _iter_blobs(self, prefix: str) -> Generator[BlobProperties]:
+        """Yield each non-directory blob under the configured prefix.
+
+        Directory markers (names ending with ``/``) are skipped.
+
+        Args:
+            prefix (str): Prefix to filter blobs
+
+        Yields:
+            BlobProperties: Each blob's properties
+        """
+        container_client = self.__client.get_container_client(self.__container_name)
+        for blob in container_client.list_blobs(name_starts_with=prefix):
+            if not blob.name.endswith("/"):
+                yield blob
+
     def get_file_list(self) -> list[str]:
         """Return all blobs under the configured prefix as unsorted Azure URIs."""
         blobs = []
-        container_client = self.__client.get_container_client(self.__container_name)
-
-        for blob in container_client.list_blobs(name_starts_with=self.prefix):
-            if blob.name.endswith("/"):
-                continue
-
-            # Add full Azure path using _to_url
+        for blob in self._iter_blobs(self.prefix):
             blobs.append(self._to_url(self.__container_name, blob.name))
-
         return blobs
 
     def get_file_list_with_metadata(self) -> list[FileInfo]:
@@ -188,13 +198,8 @@ class AzureBlobBackend(BaseBackend):
         Metadata (``last_modified``, ``size``, ``etag``) is gathered from the
         ``list_blobs`` response — no extra HEAD requests.
         """
-        container_client = self.__client.get_container_client(self.__container_name)
-
         files = []
-        for blob in container_client.list_blobs(name_starts_with=self.prefix):
-            if blob.name.endswith("/"):
-                continue
-
+        for blob in self._iter_blobs(self.prefix):
             files.append(
                 FileInfo(
                     path=self._to_url(self.__container_name, blob.name),
@@ -203,7 +208,6 @@ class AzureBlobBackend(BaseBackend):
                     file_identity=str(blob.etag) if blob.etag else None,
                 )
             )
-
         return files
 
     def get_file_size(self, file_path: str) -> int:

--- a/src/pythermondt/io/backends/base_backend.py
+++ b/src/pythermondt/io/backends/base_backend.py
@@ -1,9 +1,30 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 
 from ..utils import IOPathWrapper
 
 
+@dataclass(frozen=True)
+class FileInfo:
+    """Metadata for a file discovered by a backend.
+
+    Attributes:
+        path: Backend-specific URI (e.g. ``file://...``, ``s3://...``, ``az://...``).
+        last_modified: Timezone-aware UTC timestamp of last modification.
+        size: File size in bytes.
+        file_identity: Backend-specific identity string (e.g. ETag) for change detection.
+    """
+
+    path: str
+    last_modified: datetime
+    size: int
+    file_identity: str | None = None
+
+
 class BaseBackend(ABC):
+    """Base class for all backend implementations."""
+
     @property
     @abstractmethod
     def remote_source(self) -> bool:
@@ -39,6 +60,11 @@ class BaseBackend(ABC):
     @abstractmethod
     def get_file_list(self) -> list[str]:
         """Return all files under the configured pattern or prefix as unsorted URIs."""
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def get_file_list_with_metadata(self) -> list[FileInfo]:
+        """Return all files under the configured pattern or prefix as an unsorted list of ``FileInfo`` objects."""
         raise NotImplementedError("Subclasses must implement this method")
 
     @abstractmethod

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -112,7 +112,7 @@ class LocalBackend(BaseBackend):
         stat_result = os.stat(normalised)
         return FileInfo(
             path=self._to_url(normalised),
-            last_modified=datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc),
+            last_modified=datetime.fromtimestamp(stat_result.st_mtime_ns / 1e9, tz=timezone.utc),
             size=stat_result.st_size,
             file_identity=self._identity_from_stat(stat_result),
         )

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -1,11 +1,12 @@
 import logging
 import os
+from datetime import datetime, timezone
 from glob import glob
 from urllib.parse import urlparse
 from urllib.request import pathname2url, url2pathname
 
 from ..utils import IOPathWrapper
-from .base_backend import BaseBackend
+from .base_backend import BaseBackend, FileInfo
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,10 @@ class LocalBackend(BaseBackend):
         # Normalize and convert to URLs
         return [self._to_url(os.path.normpath(os.path.abspath(f))) for f in self._get_raw_file_paths()]
 
+    def get_file_list_with_metadata(self) -> list[FileInfo]:
+        """Return all files with metadata (single stat per file, no extra overhead)."""
+        # Build FileInfo object for each file in raw file paths
+        return [self._build_file_info(f) for f in self._get_raw_file_paths()]
 
     def _identity_from_stat(self, stat_result: os.stat_result) -> str:
         """Build a local-file identity string from a stat result."""
@@ -101,6 +106,16 @@ class LocalBackend(BaseBackend):
         inode = getattr(stat_result, "st_ino", 0)
         return f"{device}:{inode}:{stat_result.st_size}:{stat_result.st_mtime_ns}"
 
+    def _build_file_info(self, internal_path: str) -> FileInfo:
+        """Stat a local path and build a ``FileInfo`` entry (normalized, URL-encoded)."""
+        normalised = os.path.normpath(os.path.abspath(internal_path))
+        stat_result = os.stat(normalised)
+        return FileInfo(
+            path=self._to_url(normalised),
+            last_modified=datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc),
+            size=stat_result.st_size,
+            file_identity=self._identity_from_stat(stat_result),
+        )
 
     def get_file_size(self, file_path: str) -> int:
         path = self._parse_input(file_path)

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -78,7 +78,7 @@ class LocalBackend(BaseBackend):
 
     def _get_raw_file_paths(self) -> list[str]:
         """Return raw (un-normalized) file paths matching the configured source type."""
-        # Handle different pattern types ==> raise an error if the source type is unexpected
+        # Handle different pattern types
         match self.__source_type:
             case "file":
                 return [self.pattern]

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -76,24 +76,23 @@ class LocalBackend(BaseBackend):
         # Nothing to close for local files
         pass
 
-    def get_file_list(self) -> list[str]:
-        # Handle different pattern types
-        all_files = []
+    def _get_raw_file_paths(self) -> list[str]:
+        """Return raw (un-normalized) file paths matching the configured source type."""
+        # Handle different pattern types ==> return [] on no match
         match self.__source_type:
             case "file":
-                all_files = [self.pattern]
+                return [self.pattern]
             case "directory":
                 if self.__recursive:
-                    all_files = [os.path.join(root, name) for root, _, names in os.walk(self.pattern) for name in names]
-                else:
-                    all_files = [f.path for f in os.scandir(self.pattern) if f.is_file()]
+                    return [os.path.join(root, name) for root, _, names in os.walk(self.pattern) for name in names]
+                return [f.path for f in os.scandir(self.pattern) if f.is_file()]
             case "glob":
-                all_files = glob(self.pattern, recursive=self.__recursive)
+                return glob(self.pattern, recursive=self.__recursive)
+        return []
 
-        # Convert to absolute paths and normalize before returning
-        all_files = [self._to_url(os.path.normpath(os.path.abspath(f))) for f in all_files]
-
-        return all_files
+    def get_file_list(self) -> list[str]:
+        # Normalize and convert to URLs
+        return [self._to_url(os.path.normpath(os.path.abspath(f))) for f in self._get_raw_file_paths()]
 
     def get_file_size(self, file_path: str) -> int:
         path = self._parse_input(file_path)

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -94,6 +94,14 @@ class LocalBackend(BaseBackend):
         # Normalize and convert to URLs
         return [self._to_url(os.path.normpath(os.path.abspath(f))) for f in self._get_raw_file_paths()]
 
+
+    def _identity_from_stat(self, stat_result: os.stat_result) -> str:
+        """Build a local-file identity string from a stat result."""
+        device = getattr(stat_result, "st_dev", 0)
+        inode = getattr(stat_result, "st_ino", 0)
+        return f"{device}:{inode}:{stat_result.st_size}:{stat_result.st_mtime_ns}"
+
+
     def get_file_size(self, file_path: str) -> int:
         path = self._parse_input(file_path)
         if not os.path.exists(path):
@@ -115,10 +123,7 @@ class LocalBackend(BaseBackend):
             raise IsADirectoryError(f"Path is a directory, not a file: {path}")
 
         stat_result = os.stat(path)
-        device = getattr(stat_result, "st_dev", 0)
-        inode = getattr(stat_result, "st_ino", 0)
-
-        return f"{device}:{inode}:{stat_result.st_size}:{stat_result.st_mtime_ns}"
+        return self._identity_from_stat(stat_result)
 
     def download_file(self, source_path: str, destination_path: str) -> None:
         raise NotImplementedError("Direct download is not supported for local files.")

--- a/src/pythermondt/io/backends/local_backend.py
+++ b/src/pythermondt/io/backends/local_backend.py
@@ -33,7 +33,6 @@ class LocalBackend(BaseBackend):
         parsed_input = self._parse_input(pattern)
 
         # Determine the type of the source based on the provided pattern
-        self.__source_type = None
         if os.path.isfile(parsed_input):
             self.__source_type = "file"
         elif os.path.isdir(parsed_input):
@@ -79,7 +78,7 @@ class LocalBackend(BaseBackend):
 
     def _get_raw_file_paths(self) -> list[str]:
         """Return raw (un-normalized) file paths matching the configured source type."""
-        # Handle different pattern types ==> return [] on no match
+        # Handle different pattern types ==> raise an error if the source type is unexpected
         match self.__source_type:
             case "file":
                 return [self.pattern]
@@ -89,7 +88,8 @@ class LocalBackend(BaseBackend):
                 return [f.path for f in os.scandir(self.pattern) if f.is_file()]
             case "glob":
                 return glob(self.pattern, recursive=self.__recursive)
-        return []
+            case _:
+                raise RuntimeError(f"Unexpected source type: {self.__source_type!r}")
 
     def get_file_list(self) -> list[str]:
         # Normalize and convert to URLs

--- a/src/pythermondt/io/backends/s3_backend.py
+++ b/src/pythermondt/io/backends/s3_backend.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Generator
 from io import BytesIO
 from urllib.parse import urlparse
 
@@ -121,23 +122,29 @@ class S3Backend(BaseBackend):
         """
         self.__client.close()
 
-    def get_file_list(self) -> list[str]:
-        """Return all objects under the configured prefix as unsorted S3 URIs."""
-        # List all objects with the given prefix
-        paginator = self.__client.get_paginator("list_objects_v2")
+    def _iter_objects(self, prefix: str) -> Generator[dict]:
+        """Yield each non-directory object dict under the configured prefix.
 
-        files = []
-        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.prefix):
+        Directory markers (keys ending with ``/``) are skipped.
+
+        Args:
+            prefix (str): Prefix to filter objects
+
+        Yields:
+            dict: Each object's metadata from S3
+        """
+        paginator = self.__client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=prefix):
             if "Contents" in page:
                 for obj in page["Contents"]:
-                    key = obj["Key"]
-                    # Skip directories (keys ending with /)
-                    if key.endswith("/"):
-                        continue
+                    if not obj["Key"].endswith("/"):
+                        yield obj
 
-                    # Add full S3 path
-                    files.append(self._to_url(self.bucket, key))
-
+    def get_file_list(self) -> list[str]:
+        """Return all objects under the configured prefix as unsorted S3 URIs."""
+        files = []
+        for obj in self._iter_objects(self.prefix):
+            files.append(self._to_url(self.bucket, obj["Key"]))
         return files
 
     def get_file_list_with_metadata(self) -> list[FileInfo]:
@@ -146,25 +153,16 @@ class S3Backend(BaseBackend):
         Metadata (``LastModified``, ``Size``, ``ETag``) is gathered from the
         ``list_objects_v2`` response — no extra HEAD requests.
         """
-        paginator = self.__client.get_paginator("list_objects_v2")
-
         files = []
-        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.prefix):
-            if "Contents" in page:
-                for obj in page["Contents"]:
-                    key = obj["Key"]
-                    if key.endswith("/"):
-                        continue
-
-                    files.append(
-                        FileInfo(
-                            path=self._to_url(self.bucket, key),
-                            last_modified=obj["LastModified"],
-                            size=obj["Size"],
-                            file_identity=obj.get("ETag"),
-                        )
-                    )
-
+        for obj in self._iter_objects(self.prefix):
+            files.append(
+                FileInfo(
+                    path=self._to_url(self.bucket, obj["Key"]),
+                    last_modified=obj["LastModified"],
+                    size=obj["Size"],
+                    file_identity=obj.get("ETag"),
+                )
+            )
         return files
 
     def get_file_size(self, file_path: str) -> int:

--- a/src/pythermondt/io/backends/s3_backend.py
+++ b/src/pythermondt/io/backends/s3_backend.py
@@ -7,7 +7,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from ..utils import IOPathWrapper
-from .base_backend import BaseBackend
+from .base_backend import BaseBackend, FileInfo
 from .options import S3ClientOptions
 from .progress import TqdmCallback
 
@@ -137,6 +137,33 @@ class S3Backend(BaseBackend):
 
                     # Add full S3 path
                     files.append(self._to_url(self.bucket, key))
+
+        return files
+
+    def get_file_list_with_metadata(self) -> list[FileInfo]:
+        """Return all objects under the configured prefix as ``FileInfo`` entries (unsorted).
+
+        Metadata (``LastModified``, ``Size``, ``ETag``) is gathered from the
+        ``list_objects_v2`` response — no extra HEAD requests.
+        """
+        paginator = self.__client.get_paginator("list_objects_v2")
+
+        files = []
+        for page in paginator.paginate(Bucket=self.bucket, Prefix=self.prefix):
+            if "Contents" in page:
+                for obj in page["Contents"]:
+                    key = obj["Key"]
+                    if key.endswith("/"):
+                        continue
+
+                    files.append(
+                        FileInfo(
+                            path=self._to_url(self.bucket, key),
+                            last_modified=obj["LastModified"],
+                            size=obj["Size"],
+                            file_identity=obj.get("ETag"),
+                        )
+                    )
 
         return files
 

--- a/tests/io/backends/test_azure_backend.py
+++ b/tests/io/backends/test_azure_backend.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from azure.core.exceptions import AzureError
 
-from pythermondt.io import AzureBlobBackend, AzureBlobClientOptions, IOPathWrapper
+from pythermondt.io import AzureBlobBackend, AzureBlobClientOptions, FileInfo, IOPathWrapper
 
 
 @pytest.fixture
@@ -175,3 +175,22 @@ def test_to_url(azure_backend):
     """Test URL construction."""
     url = azure_backend._to_url("my-container", "path/to/file.txt")
     assert url == "az://my-container/path/to/file.txt"
+
+
+def test_get_file_list_with_metadata_skips_directories(azure_backend_with_directory):
+    """Test get_file_list_with_metadata skips directory markers and populates metadata."""
+    result = azure_backend_with_directory.get_file_list_with_metadata()
+
+    # Should skip directory marker, include actual file
+    assert all(not f.path.endswith("/") for f in result)
+    paths = [f.path for f in result]
+    assert "az://test-container/test/subdir/" not in paths
+    assert "az://test-container/test/subdir/file.txt" in paths
+
+    # Verify metadata is populated from listing (no extra HEAD requests)
+    for info in result:
+        assert isinstance(info, FileInfo)
+        assert info.last_modified.tzinfo is not None
+        assert info.size >= 0
+        assert isinstance(info.file_identity, str)
+        assert info.file_identity != ""

--- a/tests/io/backends/test_backend_interface.py
+++ b/tests/io/backends/test_backend_interface.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from pythermondt.io import IOPathWrapper
+from pythermondt.io import FileInfo, IOPathWrapper
 
 
 def test_scheme(backend_config):
@@ -181,3 +181,43 @@ def test_download_file(backend_config, tmp_path, test_file):
         with open(dest_path, "rb") as f:
             downloaded_content = f.read()
         assert downloaded_content == expected_content
+
+
+def test_get_file_list_with_metadata_single(backend_config, test_file):
+    """Test get_file_list_with_metadata returns correct FileInfo for a single file."""
+    backend_instance, _ = backend_config
+    file_path, expected_content = test_file
+
+    result = backend_instance.get_file_list_with_metadata()
+    assert len(result) == 1
+
+    info = result[0]
+    assert isinstance(info, FileInfo)
+    assert info.path == file_path
+    assert info.size == len(expected_content)
+    assert info.last_modified.tzinfo is not None  # tz-aware UTC
+    assert isinstance(info.file_identity, str)
+    assert info.file_identity != ""
+
+
+def test_get_file_list_with_metadata_all(backend_config, test_files_scenario):
+    """Test get_file_list_with_metadata with all files."""
+    backend_instance, config = backend_config
+
+    result = backend_instance.get_file_list_with_metadata()
+
+    assert len(result) == len(test_files_scenario)
+    assert all(f.path.startswith(config.scheme + "://") for f in result)
+    assert all(f.last_modified.tzinfo is not None for f in result)
+    assert all(isinstance(f.file_identity, str) and f.file_identity != "" for f in result)
+    assert all(f.size >= 0 for f in result)
+
+
+def test_get_file_list_with_metadata_paths_match_get_file_list(backend_config, test_files_scenario):
+    """Test that paths returned by both listing methods are identical."""
+    backend_instance, _ = backend_config
+
+    paths_fast = set(backend_instance.get_file_list())
+    paths_meta = {info.path for info in backend_instance.get_file_list_with_metadata()}
+
+    assert paths_fast == paths_meta

--- a/tests/io/backends/test_local_backend.py
+++ b/tests/io/backends/test_local_backend.py
@@ -396,3 +396,13 @@ def test_get_file_size_directory_raises_error(tmp_path):
     # Should raise an error when trying to get size of directory
     with pytest.raises(IsADirectoryError):
         backend.get_file_size(str(subdir))
+
+
+def test_get_raw_file_paths_invalid_source_type(tmp_path):
+    """Test that a corrupted source_type raises RuntimeError."""
+    (tmp_path / "test.txt").write_text("content")
+    backend = LocalBackend(str(tmp_path))
+    backend._LocalBackend__source_type = None  # type: ignore
+
+    with pytest.raises(RuntimeError, match="Unexpected source type"):
+        backend._get_raw_file_paths()

--- a/tests/io/backends/test_s3_backend.py
+++ b/tests/io/backends/test_s3_backend.py
@@ -7,7 +7,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
-from pythermondt.io import IOPathWrapper, S3Backend, S3ClientOptions
+from pythermondt.io import FileInfo, IOPathWrapper, S3Backend, S3ClientOptions
 
 
 @pytest.fixture
@@ -229,3 +229,22 @@ def test_prefix_property(s3_backend):
 def test_remote_source_property(s3_backend):
     """Test remote_source property."""
     assert s3_backend.remote_source is True
+
+
+def test_get_file_list_with_metadata_skips_directories(s3_backend_with_directory):
+    """Test get_file_list_with_metadata skips directory markers and populates metadata."""
+    result = s3_backend_with_directory.get_file_list_with_metadata()
+
+    # Should skip directory marker, include actual file
+    assert all(not f.path.endswith("/") for f in result)
+    paths = [f.path for f in result]
+    assert "s3://test-bucket/test/subdir/" not in paths
+    assert "s3://test-bucket/test/subdir/file.txt" in paths
+
+    # Verify metadata is populated from listing (no extra HEAD requests)
+    for info in result:
+        assert isinstance(info, FileInfo)
+        assert info.last_modified.tzinfo is not None
+        assert info.size >= 0
+        assert isinstance(info.file_identity, str)
+        assert info.file_identity != ""

--- a/tests/support/storage/azure.py
+++ b/tests/support/storage/azure.py
@@ -1,6 +1,7 @@
 import hashlib
 from collections.abc import Iterator
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -108,6 +109,9 @@ def mocked_azure_blob_storage() -> Iterator[MockAzureBlob]:
             for name in mock_storage.list_blobs(container, name_starts_with):
                 mock_blob = MagicMock()
                 mock_blob.name = name
+                mock_blob.last_modified = datetime(2024, 6, 1, tzinfo=timezone.utc)
+                mock_blob.size = mock_storage.get_blob_size(container, name)
+                mock_blob.etag = mock_storage.get_blob_etag(container, name)
                 mock_blobs.append(mock_blob)
             return mock_blobs
 


### PR DESCRIPTION
- Add `FileInfo` frozen dataclass (path, last_modified, size, file_identity) to `base_backend.py`
- Add abstract `get_file_list_with_metadata()` to `BaseBackend` returning `list[FileInfo]`
- Implement in `LocalBackend` via `_get_raw_file_paths()` refactor and new `_build_file_info`/`_identity_from_stat` helpers
- Implement in `AzureBlobBackend` via `_iter_blobs()` helper that skips directory markers; metadata sourced from `list_blobs` (no extra HEAD requests)
- Implement in `S3Backend` via `_iter_objects()` helper that skips directory markers; metadata sourced from `list_objects_v2` (no extra HEAD requests)
- Replace dead `return []` fallthrough in `LocalBackend._get_raw_file_paths` with explicit `RuntimeError` for invalid source types
- Export `FileInfo` from `pythermondt.io` and `pythermondt.io.backends`
- Add interface tests (single file, all files, path consistency with `get_file_list`) and remote-backend directory-skip tests

Adds a metadata-rich file listing API across all backends, enabling downstream consumers (e.g., change detection, caching) to avoid per-file HEAD/stat calls.