### PR TITLE
Fix sync() skipping new files when cache already exists

### DIFF
--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -451,7 +451,8 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         to both populate and validate the cache.
 
         Args:
-            file_paths (list[str], optional): Files to check. Defaults to all manifest entries.
+            file_paths (list[str], optional): Files to check. Defaults to the union of all manifest entries
+                and the reader's file URIs (so new files are discovered when `num_files` increases).
             num_workers (int, optional): Parallel workers. Defaults to global config.
         """
         # If no remote source, do nothing

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -464,8 +464,8 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             self.download(file_paths=file_paths, num_workers=num_workers)
             return
 
-        # Determine files to check
-        to_check = file_paths or list(manifest.root.keys())
+        # Include reader file URIs so files that are discoverable now but absent from the manifest
+        to_check = file_paths or list(set(manifest.root.keys()) | set(self.file_uris))
 
         def fetch_identity(remote_path: str) -> tuple[str, str | None]:
             try:


### PR DESCRIPTION
- Changed `sync()` to include `self.file_uris` when determining which files to check, so files in the reader's current scope (e.g. after `num_files` increased or new files arrived in storage) are discovered and downloaded even when a prior cache exists

Closes #409.