### PR TITLE
Pin numpy to <2.3.0 for Python 3.10 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # Data loading and visualization
     "h5py>=3.9",
     "pymatreader>=1.0",
-    "numpy>=2.0,<2.5.0",  # <2.5.0 dropped Python 3.11 support, incompatible with requires-python
+    "numpy>=2.0,<2.3.0",  # >=2.3.0 requires Python 3.11, incompatible with requires-python
     "matplotlib>=3.7",
 
     # Machine learning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     # Data loading and visualization
     "h5py>=3.9",
     "pymatreader>=1.0",
-    "numpy>=1.23",
+    "numpy>=2.0,<2.5.0",  # <2.5.0 dropped Python 3.11 support, incompatible with requires-python
     "matplotlib>=3.7",
 
     # Machine learning


### PR DESCRIPTION
- Constrain `numpy` to `>=2.0,<2.3.0` in project dependencies
- numpy 2.3.0 dropped Python 3.10 (`requires-python: >=3.11`), and 2.5.0 dropped Python 3.11 — both incompatible with pythermondt's `requires-python = ">=3.10"`
- numpy 2.2.x is the last compatible major.minor for the project's current Python floor
- Fixes a mypy CI failure where numpy 2.5.0's PEP 695 `type` statements in stubs triggered `Type statement is only supported in Python 3.12 and greater` under `python_version = "3.10"`

This keeps the dependency on numpy 2.x while avoiding versions whose type stubs use Python-version-incompatible syntax.