### PR TITLE
Fix mask truthiness checks in CropFrames and RandomFlip transforms

### DIFF
--- a/src/pythermondt/transforms/augmentation.py
+++ b/src/pythermondt/transforms/augmentation.py
@@ -45,18 +45,18 @@ class RandomFlip(RandomThermoTransform):
         # Flip the data along the height if the random number is less than p_height
         if torch.rand(1).item() < self.p_height:
             tdata = torch.flip(tdata, [1])
-            if mask:
+            if mask is not None:
                 mask = torch.flip(mask, [1])
 
         # Flip the data along the width if the random number is less than p_width
         if torch.rand(1).item() < self.p_width:
             tdata = torch.flip(tdata, [0])
-            if mask:
+            if mask is not None:
                 mask = torch.flip(mask, [0])
 
         # Update the container and return it
         updates: list[tuple[str, torch.Tensor]] = [("/Data/Tdata", tdata)]
-        if mask:
+        if mask is not None:
             updates.append(("/GroundTruth/DefectMask", mask))
         container.update_datasets(*updates)
         return container

--- a/src/pythermondt/transforms/preprocessing.py
+++ b/src/pythermondt/transforms/preprocessing.py
@@ -352,7 +352,7 @@ class CropFrames(ThermoTransform):
 
         # Build update tuples (only include mask if present and non-empty)
         updates: list[tuple[str, torch.Tensor]] = [("/Data/Tdata", tdata)]
-        if mask:
+        if mask is not None:
             mask = mask[top:bottom, left:right]
             updates.append(("/GroundTruth/DefectMask", mask))
 


### PR DESCRIPTION
Follow-up to #440.

- Replace `if mask:` with `if mask is not None:` in `CropFrames.forward()` (1 site)
- Replace `if mask:` with `if mask is not None:` in `RandomFlip.forward()` (3 sites)

Optional DefectMask tensors from `_get_optional_dataset` cannot be evaluated as booleans when they contain multiple values, which raised `RuntimeError: Boolean value of Tensor with more than one value is ambiguous`. The `is not None` check correctly tests presence without evaluating the tensor's contents.