### PR TITLE
Enable PERF and T10 ruff rules and fix violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,8 +147,7 @@ ignore = [
     "D106",   # Missing docstring in public nested class
     "D107",   # Missing docstring in `__init__`
     "RUF005", # Concatenation of collections with + operator is more readable
-    "PERF203", # try-except within a loop: structurally necessary in plugin loaders, collation, and error enrichment,
-    # where per-iteration error handling is intentional or moving it outside adds complexity for zero benefit.
+    "PERF203", # try-except in a loop is structurally necessary for per-iteration error handling
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ ignore = [
     "D106",   # Missing docstring in public nested class
     "D107",   # Missing docstring in `__init__`
     "RUF005", # Concatenation of collections with + operator is more readable
+    "PERF203", # try-except within a loop: structurally necessary in plugin loaders, collation, and error enrichment,
+    # where per-iteration error handling is intentional or moving it outside adds complexity for zero benefit.
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ select = [
     "C4", # flake8-comprehensions
     "FURB", # refurb
     "A", # flake8-builtins
+    "PERF", # perflint
+    "T10", # flake8-debugger
 ]
 fixable = ["ALL"]
 pydocstyle.convention = "google"

--- a/src/pythermondt/io/backends/azure_backend.py
+++ b/src/pythermondt/io/backends/azure_backend.py
@@ -187,10 +187,7 @@ class AzureBlobBackend(BaseBackend):
 
     def get_file_list(self) -> list[str]:
         """Return all blobs under the configured prefix as unsorted Azure URIs."""
-        blobs = []
-        for blob in self._iter_blobs(self.prefix):
-            blobs.append(self._to_url(self.__container_name, blob.name))
-        return blobs
+        return [self._to_url(self.__container_name, blob.name) for blob in self._iter_blobs(self.prefix)]
 
     def get_file_list_with_metadata(self) -> list[FileInfo]:
         """Return all blobs under the configured prefix as ``FileInfo`` entries (unsorted).
@@ -198,17 +195,15 @@ class AzureBlobBackend(BaseBackend):
         Metadata (``last_modified``, ``size``, ``etag``) is gathered from the
         ``list_blobs`` response — no extra HEAD requests.
         """
-        files = []
-        for blob in self._iter_blobs(self.prefix):
-            files.append(
-                FileInfo(
-                    path=self._to_url(self.__container_name, blob.name),
-                    last_modified=blob.last_modified,
-                    size=blob.size,
-                    file_identity=str(blob.etag) if blob.etag else None,
-                )
+        return [
+            FileInfo(
+                path=self._to_url(self.__container_name, blob.name),
+                last_modified=blob.last_modified,
+                size=blob.size,
+                file_identity=str(blob.etag) if blob.etag else None,
             )
-        return files
+            for blob in self._iter_blobs(self.prefix)
+        ]
 
     def get_file_size(self, file_path: str) -> int:
         """Get the size of the file in Azure Blob Storage in bytes.

--- a/src/pythermondt/io/backends/s3_backend.py
+++ b/src/pythermondt/io/backends/s3_backend.py
@@ -142,10 +142,7 @@ class S3Backend(BaseBackend):
 
     def get_file_list(self) -> list[str]:
         """Return all objects under the configured prefix as unsorted S3 URIs."""
-        files = []
-        for obj in self._iter_objects(self.prefix):
-            files.append(self._to_url(self.bucket, obj["Key"]))
-        return files
+        return [self._to_url(self.bucket, obj["Key"]) for obj in self._iter_objects(self.prefix)]
 
     def get_file_list_with_metadata(self) -> list[FileInfo]:
         """Return all objects under the configured prefix as ``FileInfo`` entries (unsorted).
@@ -153,17 +150,15 @@ class S3Backend(BaseBackend):
         Metadata (``LastModified``, ``Size``, ``ETag``) is gathered from the
         ``list_objects_v2`` response — no extra HEAD requests.
         """
-        files = []
-        for obj in self._iter_objects(self.prefix):
-            files.append(
-                FileInfo(
-                    path=self._to_url(self.bucket, obj["Key"]),
-                    last_modified=obj["LastModified"],
-                    size=obj["Size"],
-                    file_identity=obj.get("ETag"),
-                )
+        return [
+            FileInfo(
+                path=self._to_url(self.bucket, obj["Key"]),
+                last_modified=obj["LastModified"],
+                size=obj["Size"],
+                file_identity=obj.get("ETag"),
             )
-        return files
+            for obj in self._iter_objects(self.prefix)
+        ]
 
     def get_file_size(self, file_path: str) -> int:
         """Return the size of the file on s3 bucket in bytes."""

--- a/src/pythermondt/io/parsers/simulation_parser.py
+++ b/src/pythermondt/io/parsers/simulation_parser.py
@@ -119,11 +119,5 @@ def reshape_pymatreader_parameters(flat_params: list[Any]) -> list[list[Any]]:
     values = flat_params[3 * num_params : 4 * num_params]
     units = flat_params[4 * num_params : 5 * num_params]
 
-    # Create the column headers
-    result = []
-
     # Create a row for each parameter
-    for i in range(num_params):
-        result.append([param_names[i], expressions[i], descriptions[i], values[i], units[i]])
-
-    return result
+    return [[param_names[i], expressions[i], descriptions[i], values[i], units[i]] for i in range(num_params)]


### PR DESCRIPTION
- Enable `PERF` (perflint) and `T10` (flake8-debugger) ruff rule categories.
- Replace for-loop `.append()` patterns with list comprehensions in `S3Backend`, `AzureBlobBackend`, and `reshape_pymatreader_parameters`.
- Ignore `PERF203` (try-except in a loop): the existing usages in plugin loading, error enrichment, and collation helpers have per-iteration error handling that is structurally necessary, and refactoring them away would add complexity for no real benefit.

Adds performance linting and debugger detection rules, resolves all violations they surface, and suppresses the one rule (`PERF203`) that is a poor fit for this codebase.