### PR TITLE
Add file_filter parameter to reader classes for metadata-based file discovery

### DIFF
--- a/src/pythermondt/readers/azure_reader.py
+++ b/src/pythermondt/readers/azure_reader.py
@@ -1,6 +1,8 @@
+from collections.abc import Callable
+
 from azure.core.credentials import TokenCredential
 
-from ..io import AzureBlobBackend, AzureBlobClientOptions, BaseParser
+from ..io import AzureBlobBackend, AzureBlobClientOptions, BaseParser, FileInfo
 from .base_reader import BaseReader
 
 
@@ -18,6 +20,7 @@ class AzureBlobReader(BaseReader):
         download_files: bool = False,
         cache_files: bool = True,
         parser: type[BaseParser] | None = None,
+        file_filter: Callable[[FileInfo], bool] | None = None,
     ):
         """Initialize reader for Azure Blob Storage.
 
@@ -38,8 +41,10 @@ class AzureBlobReader(BaseReader):
                 refreshed on each access. Default: True.
             parser (type[BaseParser] | None): Parser class for reading files. If None, auto-selects
                 based on file extension. Default: None.
+            file_filter (Callable[[FileInfo], bool] | None): Metadata-aware filter applied during file discovery.
+                Default: None.
         """
-        super().__init__(num_files, download_files, cache_files, parser)
+        super().__init__(num_files, download_files, cache_files, parser, file_filter)
         self.__container_name = container_name
         self.__prefix = prefix
         self.__connection_string = connection_string

--- a/src/pythermondt/readers/azure_reader.py
+++ b/src/pythermondt/readers/azure_reader.py
@@ -41,8 +41,8 @@ class AzureBlobReader(BaseReader):
                 refreshed on each access. Default: True.
             parser (type[BaseParser] | None): Parser class for reading files. If None, auto-selects
                 based on file extension. Default: None.
-            file_filter (Callable[[FileInfo], bool] | None): Metadata-aware filter applied during file discovery.
-                Default: None.
+            file_filter (Callable[[FileInfo], bool] | None): Metadata-aware filter applied during file
+                discovery. Must be picklable whenever the reader needs to be picklable. Default: None.
         """
         super().__init__(num_files, download_files, cache_files, parser, file_filter)
         self.__container_name = container_name

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -219,10 +219,9 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             pickle.dumps(self.__file_filter)
         except (pickle.PicklingError, AttributeError, TypeError) as e:
             raise pickle.PicklingError(
-                f"{type(self).__name__}.file_filter must be picklable whenever the reader is "
-                f"pickled (spawn/forkserver workers, torch.save, DDP), but got "
-                f"{self.__file_filter!r}. Use a module-level function or a picklable class "
-                f"instance instead of a lambda or closure."
+                f"{type(self).__name__}.file_filter is not picklable: {self.__file_filter!r}. "
+                f"Use a module-level function or a picklable class instance instead of a "
+                f"lambda or closure."
             ) from e
 
     def __getstate__(self):

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -160,18 +160,23 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     @property
     def file_uris(self) -> list[str]:
         """List of URL-encoded URIs for internal use (reading, downloading, caching)."""
-        if self.__file_filter is not None:
-            return [entry.path for entry in self.file_entries]
-
-        # If caching is disabled return the file list from the backend
+        # If caching is disabled return the file list from the backend on each access
         if not self.__cache_files:
+            if self.__file_filter is not None:
+                return [entry.path for entry in self.file_entries]
+            # Fast path: if no filter is requested get_file_list() is sufficient because file Metadata is not needed
+            # ==> avoids additional stat() calls on every file for local backends
             return self._filter_and_limit(self.backend.get_file_list())
 
-        # If URIs have never been loaded, load them from the backend
+        # If URIs have never been loaded, derive them from file_entries (filtered) or the fast
+        # listing path (unfiltered), and cache the result.
         if self.__file_uris is None:
-            self.__file_uris = self._filter_and_limit(self.backend.get_file_list())
+            if self.__file_filter is not None:
+                self.__file_uris = [entry.path for entry in self.file_entries]
+            else:
+                # Fast path (see above): no filter => no metadata needed.
+                self.__file_uris = self._filter_and_limit(self.backend.get_file_list())
 
-        # Return the cached URIs list
         return self.__file_uris
 
     @property

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -282,13 +282,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         return os.path.basename(unquote(urlparse(file_path).path))
 
     def _has_supported_extension(self, path: str) -> bool:
-        """Return True if *path* matches one of the supported extensions.
-
-        Shared by both ``_filter_and_limit`` and ``_filter_and_limit_entries``
-        so the extension-matching rule stays consistent across listing paths.
-        """
-        if not self.__supported_extensions:
-            return True
+        """Shared helper that returns True if *path* matches one of the supported extensions."""
         return any(path.endswith(ext) for ext in self.__supported_extensions)
 
     def _sort_and_limit(self, items: list, *, key=None) -> list:

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from functools import partial
 from multiprocessing.pool import ThreadPool
 from threading import Lock
@@ -14,7 +14,7 @@ from tqdm.auto import tqdm
 
 from ..config import settings
 from ..data import DataContainer
-from ..io import BaseBackend, IOPathWrapper
+from ..io import BaseBackend, FileInfo, IOPathWrapper
 from ..io.parsers import BaseParser, find_parser_for_extension, get_all_supported_extensions
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         download_files: bool = False,
         cache_files: bool = True,
         parser: type[BaseParser] | None = None,
+        file_filter: Callable[[FileInfo], bool] | None = None,
     ):
         """Initialize an instance of the BaseReader class.
 
@@ -57,15 +58,19 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
                 the parser will be auto selected based on the file extension. Default is None.
+            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file discovery.
+                Use picklable callables when readers are used with multiprocessing. Default is None.
         """
         # Assign private attributes
         self.__parser = parser
         self.__num_files = num_files
         self.__cache_files = cache_files
         self.__download_files = download_files
+        self.__file_filter = file_filter
 
         # Internal state
         self.__backend: BaseBackend | None = None
+        self.__file_entries: list[FileInfo] | None = None
         self.__files: list[str] | None = None
         self.__file_uris: list[str] | None = None
         self.__file_names: list[str] | None = None
@@ -116,6 +121,11 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         return self.__parser
 
     @property
+    def file_filter(self) -> Callable[[FileInfo], bool] | None:
+        """The metadata-aware file filter used during file discovery."""
+        return self.__file_filter
+
+    @property
     def num_files(self) -> int | None:
         """The number of files to read."""
         return self.__num_files
@@ -150,6 +160,9 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     @property
     def file_uris(self) -> list[str]:
         """List of URL-encoded URIs for internal use (reading, downloading, caching)."""
+        if self.__file_filter is not None:
+            return [entry.path for entry in self.file_entries]
+
         # If caching is disabled return the file list from the backend
         if not self.__cache_files:
             return self._filter_and_limit(self.backend.get_file_list())
@@ -160,6 +173,21 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
         # Return the cached URIs list
         return self.__file_uris
+
+    @property
+    def file_entries(self) -> list[FileInfo]:
+        """List of discovered files with metadata.
+
+        This property always uses the metadata-aware backend listing. ``file_uris`` only derives from it when a
+        ``file_filter`` is configured, preserving the fast listing path for unfiltered readers.
+        """
+        if not self.__cache_files:
+            return self._filter_and_limit_entries(self.backend.get_file_list_with_metadata())
+
+        if self.__file_entries is None:
+            self.__file_entries = self._filter_and_limit_entries(self.backend.get_file_list_with_metadata())
+
+        return self.__file_entries
 
     @property
     def file_names(self) -> list[str]:
@@ -184,6 +212,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             state["_BaseReader__manifest_lock"] = None
 
         # Clear files cache to force reloading
+        state["_BaseReader__file_entries"] = None
         state["_BaseReader__files"] = None
         state["_BaseReader__file_uris"] = None
         state["_BaseReader__file_names"] = None
@@ -249,6 +278,22 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         if self.num_files is not None:
             files = files[: self.num_files]
         return files
+
+    def _filter_and_limit_entries(self, file_entries: list[FileInfo]) -> list[FileInfo]:
+        """Apply extension filtering, metadata filtering, sort, and num_files limit."""
+        if self.__supported_extensions:
+            file_entries = [
+                entry for entry in file_entries if any(entry.path.endswith(ext) for ext in self.__supported_extensions)
+            ]
+
+        if self.__file_filter is not None:
+            file_entries = [entry for entry in file_entries if self.__file_filter(entry)]
+
+        file_entries.sort(key=lambda entry: entry.path)
+
+        if self.num_files is not None:
+            file_entries = file_entries[: self.num_files]
+        return file_entries
 
     def _load_manifest(self, manifest_path: str) -> CacheManifest:
         """Load manifest from disk with thread safety."""

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -266,15 +266,23 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         """Extract the file name from a file path."""
         return os.path.basename(unquote(urlparse(file_path).path))
 
+    def _has_supported_extension(self, path: str) -> bool:
+        """Return True if *path* matches one of the supported extensions.
+
+        Shared by both ``_filter_and_limit`` and ``_filter_and_limit_entries``
+        so the extension-matching rule stays consistent across listing paths.
+        """
+        if not self.__supported_extensions:
+            return True
+        return any(path.endswith(ext) for ext in self.__supported_extensions)
+
     def _filter_and_limit(self, files: list[str]) -> list[str]:
         """Apply extension filtering, sort, and num_files limit.
 
         Filtering is applied in the reader so backends stay portable and only
         need to return the complete, unfiltered file listing.
         """
-        # Filter by extension if provided
-        if self.__supported_extensions:
-            files = [f for f in files if any(f.endswith(ext) for ext in self.__supported_extensions)]
+        files = [f for f in files if self._has_supported_extension(f)]
 
         # Sort for deterministic behavior
         files.sort()
@@ -286,13 +294,10 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
     def _filter_and_limit_entries(self, file_entries: list[FileInfo]) -> list[FileInfo]:
         """Apply extension filtering, metadata filtering, sort, and num_files limit."""
-        if self.__supported_extensions:
-            file_entries = [
-                entry for entry in file_entries if any(entry.path.endswith(ext) for ext in self.__supported_extensions)
-            ]
+        file_entries = [e for e in file_entries if self._has_supported_extension(e.path)]
 
         if self.__file_filter is not None:
-            file_entries = [entry for entry in file_entries if self.__file_filter(entry)]
+            file_entries = [e for e in file_entries if self.__file_filter(e)]
 
         file_entries.sort(key=lambda entry: entry.path)
 

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import pickle
 import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
@@ -59,7 +60,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
                 the parser will be auto selected based on the file extension. Default is None.
             file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file discovery.
-                Use picklable callables when readers are used with multiprocessing. Default is None.
+                Must be picklable whenever the reader needs to be picklable. Default: None.
         """
         # Assign private attributes
         self.__parser = parser
@@ -205,8 +206,28 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
         return self.__file_names
 
+    def _validate_file_filter_picklable(self) -> None:
+        """Fail early with a clear message when *file_filter* cannot be pickled.
+
+        Fires only when the reader is serialized (spawn/forkserver workers,
+        ``torch.save``, DDP).  Invisible to ``fork`` (which never pickles) and
+        to all single-process use.
+        """
+        if self.__file_filter is None:
+            return
+        try:
+            pickle.dumps(self.__file_filter)
+        except (pickle.PicklingError, AttributeError, TypeError) as e:
+            raise pickle.PicklingError(
+                f"{type(self).__name__}.file_filter must be picklable whenever the reader is "
+                f"pickled (spawn/forkserver workers, torch.save, DDP), but got "
+                f"{self.__file_filter!r}. Use a module-level function or a picklable class "
+                f"instance instead of a lambda or closure."
+            ) from e
+
     def __getstate__(self):
         """Prepare object for pickling by removing the backend."""
+        self._validate_file_filter_picklable()
         state = self.__dict__.copy()
         # Remove backend reference - will be recreated when needed
         if "_BaseReader__backend" in state:

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -276,6 +276,17 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             return True
         return any(path.endswith(ext) for ext in self.__supported_extensions)
 
+    def _sort_and_limit(self, items: list, *, key=None) -> list:
+        """Sort and apply the num_files limit in-place.
+
+        Shared by both ``_filter_and_limit`` and ``_filter_and_limit_entries``
+        so sort/limit behaviour stays consistent across listing paths.
+        """
+        items.sort(key=key)
+        if self.num_files is not None:
+            items = items[: self.num_files]
+        return items
+
     def _filter_and_limit(self, files: list[str]) -> list[str]:
         """Apply extension filtering, sort, and num_files limit.
 
@@ -283,14 +294,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         need to return the complete, unfiltered file listing.
         """
         files = [f for f in files if self._has_supported_extension(f)]
-
-        # Sort for deterministic behavior
-        files.sort()
-
-        # Limit number of results if specified
-        if self.num_files is not None:
-            files = files[: self.num_files]
-        return files
+        return self._sort_and_limit(files)
 
     def _filter_and_limit_entries(self, file_entries: list[FileInfo]) -> list[FileInfo]:
         """Apply extension filtering, metadata filtering, sort, and num_files limit."""
@@ -299,11 +303,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         if self.__file_filter is not None:
             file_entries = [e for e in file_entries if self.__file_filter(e)]
 
-        file_entries.sort(key=lambda entry: entry.path)
-
-        if self.num_files is not None:
-            file_entries = file_entries[: self.num_files]
-        return file_entries
+        return self._sort_and_limit(file_entries, key=lambda e: e.path)
 
     def _load_manifest(self, manifest_path: str) -> CacheManifest:
         """Load manifest from disk with thread safety."""

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -206,27 +206,18 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
         return self.__file_names
 
-    def _validate_file_filter_picklable(self) -> None:
-        """Fail early with a clear message when *file_filter* cannot be pickled.
-
-        Fires only when the reader is serialized (spawn/forkserver workers,
-        ``torch.save``, DDP).  Invisible to ``fork`` (which never pickles) and
-        to all single-process use.
-        """
-        if self.__file_filter is None:
-            return
-        try:
-            pickle.dumps(self.__file_filter)
-        except (pickle.PicklingError, AttributeError, TypeError) as e:
-            raise pickle.PicklingError(
-                f"{type(self).__name__}.file_filter is not picklable: {self.__file_filter!r}. "
-                f"Use a module-level function or a picklable class instance instead of a "
-                f"lambda or closure."
-            ) from e
-
     def __getstate__(self):
         """Prepare object for pickling by removing the backend."""
-        self._validate_file_filter_picklable()
+        # Check if file filter is pickleable to fail early with clear error message if not
+        if self.__file_filter is not None:
+            try:
+                pickle.dumps(self.__file_filter)
+            except (pickle.PicklingError, AttributeError, TypeError) as e:
+                raise pickle.PicklingError(
+                    f"{type(self).__name__}.file_filter is not picklable: {self.__file_filter!r}. Use a module-level "
+                    f"function or a picklable class instance instead of a lambda or closure."
+                ) from e
+
         state = self.__dict__.copy()
         # Remove backend reference - will be recreated when needed
         if "_BaseReader__backend" in state:

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -169,30 +169,34 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             # ==> avoids additional stat() calls on every file for local backends
             return self._filter_and_limit(self.backend.get_file_list())
 
-        # If URIs have never been loaded, derive them from file_entries (filtered) or the fast
-        # listing path (unfiltered), and cache the result.
-        if self.__file_uris is None:
-            if self.__file_filter is not None:
-                self.__file_uris = [entry.path for entry in self.file_entries]
-            else:
-                # Fast path (see above): no filter => no metadata needed.
-                self.__file_uris = self._filter_and_limit(self.backend.get_file_list())
+        # Return the cached URIs if already populated.
+        cached_uris = self.__file_uris
+        if cached_uris is not None:
+            return cached_uris
 
+        # Populate both caches from a single backend snapshot so URIs and entries stay consistent.
+        self.__file_entries = self._filter_and_limit_entries(self.backend.get_file_list_with_metadata())
+        self.__file_uris = [entry.path for entry in self.__file_entries]
         return self.__file_uris
 
     @property
     def file_entries(self) -> list[FileInfo]:
         """List of discovered files with metadata.
 
-        This property always uses the metadata-aware backend listing. ``file_uris`` only derives from it when a
-        ``file_filter`` is configured, preserving the fast listing path for unfiltered readers.
+        Metadata-aware backend listing. When caching is enabled, both ``file_uris`` and ``file_entries`` are
+        derived from the same backend snapshot so the cached lists stay consistent.
         """
         if not self.__cache_files:
             return self._filter_and_limit_entries(self.backend.get_file_list_with_metadata())
 
-        if self.__file_entries is None:
-            self.__file_entries = self._filter_and_limit_entries(self.backend.get_file_list_with_metadata())
+        # Return the cached entries if already populated.
+        cached_entries = self.__file_entries
+        if cached_entries is not None:
+            return cached_entries
 
+        # Populate both caches from a single backend snapshot so entries and URIs stay consistent.
+        self.__file_entries = self._filter_and_limit_entries(self.backend.get_file_list_with_metadata())
+        self.__file_uris = [entry.path for entry in self.__file_entries]
         return self.__file_entries
 
     @property

--- a/src/pythermondt/readers/local_reader.py
+++ b/src/pythermondt/readers/local_reader.py
@@ -1,4 +1,6 @@
-from ..io import BaseParser, LocalBackend
+from collections.abc import Callable
+
+from ..io import BaseParser, FileInfo, LocalBackend
 from .base_reader import BaseReader
 
 
@@ -10,6 +12,7 @@ class LocalReader(BaseReader):
         num_files: int | None = None,
         cache_files: bool = True,
         parser: type[BaseParser] | None = None,
+        file_filter: Callable[[FileInfo], bool] | None = None,
     ):
         """Initialize an instance of the LocalReader class.
 
@@ -26,9 +29,11 @@ class LocalReader(BaseReader):
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
                 the parser will be auto selected based on the file extension. Default is None.
+            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file discovery.
+                Default is None.
         """
         # Initialize baseclass with parser
-        super().__init__(num_files, False, cache_files, parser)
+        super().__init__(num_files, False, cache_files, parser, file_filter)
 
         # Maintain state for what is needed to create the backend
         self.__pattern = pattern

--- a/src/pythermondt/readers/local_reader.py
+++ b/src/pythermondt/readers/local_reader.py
@@ -29,8 +29,8 @@ class LocalReader(BaseReader):
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
                 the parser will be auto selected based on the file extension. Default is None.
-            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file discovery.
-                Default is None.
+            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file
+                discovery. Must be picklable whenever the reader needs to be picklable. Default: None.
         """
         # Initialize baseclass with parser
         super().__init__(num_files, False, cache_files, parser, file_filter)

--- a/src/pythermondt/readers/s3_reader.py
+++ b/src/pythermondt/readers/s3_reader.py
@@ -43,8 +43,8 @@ class S3Reader(BaseReader):
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
                 the parser will be auto selected based on the file extension. Default is None.
-            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file discovery.
-                Default is None.
+            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file
+                discovery. Must be picklable whenever the reader needs to be picklable. Default: None.
         """
         # Initialize baseclass with parser
         super().__init__(num_files, download_files, cache_files, parser, file_filter)

--- a/src/pythermondt/readers/s3_reader.py
+++ b/src/pythermondt/readers/s3_reader.py
@@ -1,6 +1,8 @@
+from collections.abc import Callable
+
 import boto3
 
-from ..io import BaseParser, S3Backend, S3ClientOptions
+from ..io import BaseParser, FileInfo, S3Backend, S3ClientOptions
 from .base_reader import BaseReader
 
 
@@ -17,6 +19,7 @@ class S3Reader(BaseReader):
         download_files: bool = False,
         cache_files: bool = True,
         parser: type[BaseParser] | None = None,
+        file_filter: Callable[[FileInfo], bool] | None = None,
     ):
         """Initialize an instance of the S3Reader class.
 
@@ -40,9 +43,11 @@ class S3Reader(BaseReader):
                 detected files will be reflected at runtime. Default is True.
             parser (Type[BaseParser], optional): The parser that the reader uses to parse the data. If not specified,
                 the parser will be auto selected based on the file extension. Default is None.
+            file_filter (Callable[[FileInfo], bool], optional): Metadata-aware filter applied during file discovery.
+                Default is None.
         """
         # Initialize baseclass with parser
-        super().__init__(num_files, download_files, cache_files, parser)
+        super().__init__(num_files, download_files, cache_files, parser, file_filter)
 
         # Maintain state for what is needed to create the backend
         self.__bucket = bucket

--- a/tests/reader/conftest.py
+++ b/tests/reader/conftest.py
@@ -5,7 +5,7 @@ from typing import Protocol, cast
 
 import pytest
 
-from pythermondt.io import AzureBlobBackend, BaseBackend, LocalBackend, S3Backend
+from pythermondt.io import AzureBlobBackend, BaseBackend, FileInfo, LocalBackend, S3Backend
 from pythermondt.io.parsers import BaseParser
 from pythermondt.readers import AzureBlobReader, BaseReader, LocalReader, S3Reader
 from tests.support import storage
@@ -18,6 +18,8 @@ class ReaderFactory(Protocol):
         self,
         parser: type[BaseParser] | None = ...,
         num_files: int | None = ...,
+        cache_files: bool = ...,
+        file_filter: Callable[[FileInfo], bool] | None = ...,
     ) -> BaseReader: ...
 
 
@@ -67,18 +69,37 @@ def reader_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[R
         backend = LocalBackend(pattern=str(tmp_path))
 
         def make_reader(
-            parser: type[BaseParser] | None = storage.PlainTextParser, num_files: int | None = None
+            parser: type[BaseParser] | None = storage.PlainTextParser,
+            num_files: int | None = None,
+            cache_files: bool = True,
+            file_filter: Callable[[FileInfo], bool] | None = None,
         ) -> BaseReader:
-            return LocalReader(pattern=str(tmp_path), num_files=num_files, parser=parser)
+            return LocalReader(
+                pattern=str(tmp_path),
+                num_files=num_files,
+                parser=parser,
+                cache_files=cache_files,
+                file_filter=file_filter,
+            )
 
     elif config.reader_cls == S3Reader:
         s3_client.create_bucket(Bucket="test-bucket")
         backend = S3Backend(bucket="test-bucket", prefix="")
 
         def make_reader(
-            parser: type[BaseParser] | None = storage.PlainTextParser, num_files: int | None = None
+            parser: type[BaseParser] | None = storage.PlainTextParser,
+            num_files: int | None = None,
+            cache_files: bool = True,
+            file_filter: Callable[[FileInfo], bool] | None = None,
         ) -> BaseReader:
-            return S3Reader(bucket="test-bucket", prefix="", num_files=num_files, parser=parser)
+            return S3Reader(
+                bucket="test-bucket",
+                prefix="",
+                num_files=num_files,
+                parser=parser,
+                cache_files=cache_files,
+                file_filter=file_filter,
+            )
 
     elif config.reader_cls == AzureBlobReader:
         azure_mock.create_container("test-container")
@@ -90,7 +111,10 @@ def reader_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[R
         )
 
         def make_reader(
-            parser: type[BaseParser] | None = storage.PlainTextParser, num_files: int | None = None
+            parser: type[BaseParser] | None = storage.PlainTextParser,
+            num_files: int | None = None,
+            cache_files: bool = True,
+            file_filter: Callable[[FileInfo], bool] | None = None,
         ) -> BaseReader:
             return AzureBlobReader(
                 account_url="https://test.blob.core.windows.net",
@@ -101,6 +125,8 @@ def reader_config(request, tmp_path: Path, s3_client, azure_mock) -> Generator[R
                 ),
                 num_files=num_files,
                 parser=parser,
+                cache_files=cache_files,
+                file_filter=file_filter,
             )
 
     else:

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -1,10 +1,37 @@
+import pickle
+from collections.abc import Callable
 from re import escape
 
 import pytest
 
 from pythermondt.data import DataContainer
+from pythermondt.io import FileInfo
 from tests.reader.conftest import ReaderTestContext, ReaderTestData
 from tests.support.storage import PlainTextParser
+
+
+def _picklable_filter(info: FileInfo) -> bool:
+    """Module-level filter for pickle test success case."""
+    return "sample1" in info.path
+
+
+class _PicklableCallable:
+    """Callable class filter for pickle test success case."""
+
+    def __init__(self, pattern: str):
+        self.pattern = pattern
+
+    def __call__(self, info: FileInfo) -> bool:
+        return self.pattern in info.path
+
+
+def _make_closure(pattern: str) -> Callable[[FileInfo], bool]:
+    """Return a non-picklable closure for pickle test failure case."""
+
+    def closure(info: FileInfo) -> bool:
+        return pattern in info.path
+
+    return closure
 
 
 def _assert_payload(container: DataContainer) -> str:
@@ -99,3 +126,124 @@ def test_read_file_without_matching_parser_raises(reader_test_data: ReaderTestDa
 
     with pytest.raises(ValueError, match=escape("No parser found for file extension: .test")):
         reader.read_file(reader_test_data.files["sample1.test"])
+
+
+def test_file_entries_contains_metadata(reader_test_data: ReaderTestData):
+    """Each FileInfo entry carries valid path, size, timestamp, and identity."""
+    entries = reader_test_data.reader.file_entries
+
+    assert len(entries) == len(reader_test_data.expected_files)
+    for entry in entries:
+        assert isinstance(entry.path, str)
+        assert entry.size > 0
+        assert entry.last_modified.tzinfo is not None
+        assert isinstance(entry.file_identity, str)
+
+
+def test_file_uris_and_file_entries_are_consistent(reader_test_data: ReaderTestData):
+    """file_uris and file_entries are derived from the same sorted snapshot."""
+    reader = reader_test_data.reader
+
+    uris = reader.file_uris
+    entries = reader.file_entries
+
+    assert len(uris) == len(entries)
+    for uri, entry in zip(uris, entries, strict=True):
+        assert uri == entry.path
+
+
+def test_file_filter_includes_only_matching_files(reader_config: ReaderTestContext):
+    """Filter restricts both file_uris and file_entries to matching files."""
+    a_uri = reader_config.prepare_file("a.test", b"a")
+    b_uri = reader_config.prepare_file("b.test", b"b")
+    reader_config.prepare_file("skip1.test", b"s1")
+    reader_config.prepare_file("skip2.test", b"s2")
+
+    reader = reader_config.make_reader(file_filter=lambda f: f.path in {a_uri, b_uri})
+
+    assert sorted(reader.file_uris) == sorted([a_uri, b_uri])
+    assert len(reader.file_entries) == 2
+    assert {e.path for e in reader.file_entries} == {a_uri, b_uri}
+
+
+def test_file_filter_with_num_files(reader_config: ReaderTestContext):
+    """Filter applies before num_files truncation."""
+    a_uri = reader_config.prepare_file("a.test", b"a")
+    b_uri = reader_config.prepare_file("b.test", b"b")
+    reader_config.prepare_file("skip1.test", b"s1")
+    reader_config.prepare_file("skip2.test", b"s2")
+
+    reader = reader_config.make_reader(file_filter=lambda f: f.path in {a_uri, b_uri}, num_files=1)
+
+    assert len(reader.file_uris) == 1
+    assert len(reader.file_entries) == 1
+
+
+def test_cache_files_false_reflects_changes(reader_config: ReaderTestContext):
+    """Without caching, adding a file is reflected immediately in URIs and entries."""
+    reader_config.prepare_file("a.test", b"a")
+    reader_config.prepare_file("b.test", b"b")
+
+    reader = reader_config.make_reader(cache_files=False)
+
+    uris_before = reader.file_uris
+    entries_before = reader.file_entries
+
+    reader_config.prepare_file("c.test", b"c")
+
+    assert len(reader.file_uris) == len(uris_before) + 1
+    assert len(reader.file_entries) == len(entries_before) + 1
+
+
+def test_cache_files_false_with_filter_excludes_new(reader_config: ReaderTestContext):
+    """Without caching, a new file excluded by the filter is not reflected."""
+    a_uri = reader_config.prepare_file("a.test", b"a")
+
+    reader = reader_config.make_reader(cache_files=False, file_filter=lambda f: f.path == a_uri)
+
+    assert len(reader.file_uris) == 1
+    assert len(reader.file_entries) == 1
+
+    reader_config.prepare_file("b.test", b"b")  # excluded by filter
+
+    assert len(reader.file_uris) == 1
+    assert len(reader.file_entries) == 1
+
+
+@pytest.mark.parametrize(
+    "filter_fn, expect_failure",
+    [
+        (lambda f: True, True),
+        (_make_closure(".test"), True),
+        (_picklable_filter, False),
+        (_PicklableCallable(".test"), False),
+    ],
+    ids=["lambda", "closure", "module_fn", "callable_class"],
+)
+def test_file_filter_pickle(
+    reader_config: ReaderTestContext,
+    filter_fn: Callable[[FileInfo], bool],
+    expect_failure: bool,
+):
+    """Non-picklable filters raise PicklingError; picklable filters survive a roundtrip."""
+    reader_config.prepare_file("sample1.test", b"a")
+    reader_config.prepare_file("sample2.test", b"b")
+
+    reader = reader_config.make_reader(file_filter=filter_fn)
+
+    if expect_failure:
+        with pytest.raises(pickle.PicklingError):
+            pickle.dumps(reader)
+        return
+
+    original_uris = reader.file_uris
+
+    restored = pickle.loads(pickle.dumps(reader))
+
+    assert restored.backend is not None
+    assert restored.file_filter is not None
+    assert restored.file_uris == original_uris
+
+    first_uri = original_uris[0]
+    container = restored.read_file(first_uri)
+    assert _assert_payload(container) is not None

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -223,6 +223,42 @@ def test_cache_files_false_with_filter_excludes_new(reader_config: ReaderTestCon
     assert len(reader.file_entries) == 1
 
 
+@pytest.mark.parametrize("num_files", [1, 3, 10, 100, None], ids=["1", "3", "10", "100", "None"])
+@pytest.mark.parametrize("cache_files", [True, False], ids=["cache_files=True", "cache_files=False"])
+@pytest.mark.parametrize("parser", [PlainTextParser, None], ids=["parser", "no_parser"])
+@pytest.mark.parametrize("file_filter", [None, _picklable_filter], ids=["no_filter", "picklable_filter"])
+def test_file_filter_combinations(
+    reader_config: ReaderTestContext,
+    num_files: int | None,
+    cache_files: bool,
+    parser: type[PlainTextParser] | None,
+    file_filter: Callable[[FileInfo], bool] | None,
+):
+    """Test that file_filter, num_files, and cache_files interact correctly."""
+    reader_config.prepare_file("sample1_a.test", b"ma")
+    reader_config.prepare_file("sample1_b.test", b"mb")
+    reader_config.prepare_file("other_1.test", b"o1")
+    reader_config.prepare_file("other_2.test", b"o2")
+
+    # Construct reader with the given parameters
+    reader = reader_config.make_reader(
+        file_filter=file_filter, num_files=num_files, cache_files=cache_files, parser=parser
+    )
+
+    # Construct expected file counts
+    total_available = 0 if parser is None else (2 if file_filter is not None else 4)
+    expected = min(num_files or total_available, total_available)
+
+    assert len(reader.file_uris) == expected
+    assert len(reader.file_entries) == expected
+
+    for uri, entry in zip(reader.file_uris, reader.file_entries, strict=True):
+        assert uri == entry.path
+
+    if file_filter is not None and parser is not None:
+        assert all("sample1" in uri for uri in reader.file_uris)
+
+
 @pytest.mark.parametrize(
     "filter_fn, expect_failure",
     [

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -236,6 +236,7 @@ def test_file_filter_combinations(
     file_filter: Callable[[FileInfo], bool] | None,
 ):
     """Test that file_filter, num_files, and cache_files interact correctly."""
+    # Prepare test files to read
     reader_config.prepare_file("sample1_a.test", b"ma")
     reader_config.prepare_file("sample1_b.test", b"mb")
     reader_config.prepare_file("other_1.test", b"o1")
@@ -250,12 +251,17 @@ def test_file_filter_combinations(
     total_available = 0 if parser is None else (2 if file_filter is not None else 4)
     expected = min(num_files or total_available, total_available)
 
+    # Assert reader length
     assert len(reader.file_uris) == expected
     assert len(reader.file_entries) == expected
+    assert len(reader.files) == expected
+    assert len(reader.file_names) == expected
 
+    # Assert file entries and URIs are consistent
     for uri, entry in zip(reader.file_uris, reader.file_entries, strict=True):
         assert uri == entry.path
 
+    # Assert file names
     if file_filter is not None and parser is not None:
         assert all("sample1" in uri for uri in reader.file_uris)
 

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -51,6 +51,19 @@ def test_parser_class(reader_config: ReaderTestContext):
     assert reader_config.reader.parser == PlainTextParser
 
 
+def test_str_representation(reader_config: ReaderTestContext):
+    """__str__ exposes class name, _get_reader_params output, num_files, download_files, cache_files, and parser."""
+    reader = reader_config.reader
+    s = str(reader)
+
+    assert reader.__class__.__name__ in s
+    assert reader.parser is not None and reader.parser == PlainTextParser
+    assert f"num_files={reader.num_files}" in s
+    assert f"download_remote_files={reader.download_files}" in s
+    assert f"cache_files={reader.cache_files}" in s
+    assert f"parser={reader.parser.__name__}" in s
+
+
 def test_files_use_parser_extensions(reader_test_data: ReaderTestData):
     """Test that reader file discovery respects parser-supported extensions."""
     expected_scheme = reader_test_data.context.config.scheme

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -6,6 +6,7 @@ import pytest
 
 from pythermondt.data import DataContainer
 from pythermondt.io import FileInfo
+from pythermondt.readers import BaseReader
 from tests.reader.conftest import ReaderTestContext, ReaderTestData
 from tests.support.storage import PlainTextParser
 
@@ -275,24 +276,26 @@ def test_file_filter_pickle(
     expect_failure: bool,
 ):
     """Non-picklable filters raise PicklingError; picklable filters survive a roundtrip."""
+    # Setup reader and test files
     reader_config.prepare_file("sample1.test", b"a")
     reader_config.prepare_file("sample2.test", b"b")
-
     reader = reader_config.make_reader(file_filter=filter_fn)
 
+    # Fail for lambda and closure filters
     if expect_failure:
         with pytest.raises(pickle.PicklingError):
             pickle.dumps(reader)
         return
 
+    # Restore
     original_uris = reader.file_uris
+    restored: BaseReader = pickle.loads(pickle.dumps(reader))
 
-    restored = pickle.loads(pickle.dumps(reader))
-
+    # Assert that the restored reader is correctly configured
     assert restored.backend is not None
     assert restored.file_filter is not None
     assert restored.file_uris == original_uris
 
-    first_uri = original_uris[0]
-    container = restored.read_file(first_uri)
-    assert _assert_payload(container) is not None
+    # Assert reader can still read files after being restored
+    container = restored.read_file(original_uris[0])
+    assert _assert_payload(container) == "a"


### PR DESCRIPTION
- Add `file_filter` (`Callable[[FileInfo], bool] | None`) to BaseReader, LocalReader, S3Reader, and AzureBlobReader
- Expose `file_entries` property returning `list[FileInfo]` with path, size, and timestamps
- Derive `file_uris` and `file_entries` from the same backend snapshot for consistency
- Add picklability guard in `__getstate__` that rejects lambdas/closures with a clear error
- Deduplicate extension filtering and sort/limit into shared helpers
- Add tests for filter behavior, caching, pickle roundtrip, and parameter combinations

Only relevant files are now discovered at the reader level, avoiding unnecessary downloads of excluded files.

Closes #394