### PR TITLE
Implement IOPathWrapper buffer protocol to enable proper read-write file-like usage

### DIFF
--- a/src/pythermondt/io/utils.py
+++ b/src/pythermondt/io/utils.py
@@ -24,25 +24,30 @@ class IOPathWrapper:
         self.__file_obj: BytesIO | None = None
         self.__temp_path: str | None = None
 
+    def _init_buffer(self) -> BytesIO:
+        """Lazy-init and return the internal buffer without seeking."""
+        if self.__file_obj is not None:
+            return self.__file_obj
+
+        buffer: BytesIO
+        if isinstance(self.__source, str):
+            with open(self.__source, "rb") as f:
+                buffer = BytesIO(f.read())
+        elif isinstance(self.__source, bytes):
+            buffer = BytesIO(self.__source)
+        elif isinstance(self.__source, BytesIO):
+            buffer = self.__source
+        else:
+            raise ValueError("Unsupported source type. Must be str, bytes, or BytesIO.")
+        self.__file_obj = buffer
+        return buffer
+
     @property
     def file_obj(self) -> BytesIO:
         """Get file-like object, loading from path if needed."""
-        if self.__file_obj is None:
-            if isinstance(self.__source, str):
-                # Path provided - load file when first needed
-                with open(self.__source, "rb") as f:
-                    self.__file_obj = BytesIO(f.read())
-            elif isinstance(self.__source, bytes):
-                self.__file_obj = BytesIO(self.__source)
-            elif isinstance(self.__source, BytesIO):
-                # File-like object provided (from boto3 etc.)
-                self.__file_obj = self.__source
-            else:
-                raise ValueError("Unsupported source type. Must be str, bytes, or BytesIO.")
-
-        # Reset position and return
-        self.__file_obj.seek(0)
-        return self.__file_obj
+        buffer = self._init_buffer()
+        buffer.seek(0)
+        return buffer
 
     @property
     def file_path(self) -> str:
@@ -92,17 +97,11 @@ class IOPathWrapper:
         """
         if isinstance(data, str):
             data = data.encode()
-        if self.__file_obj is None:
-            _ = self.file_obj
-        assert self.__file_obj is not None
-        return self.__file_obj.write(data)
+        return self._init_buffer().write(data)
 
     def getvalue(self) -> bytes:
         """Return the current contents of the internal buffer as bytes."""
-        if self.__file_obj is None:
-            _ = self.file_obj
-        assert self.__file_obj is not None
-        return self.__file_obj.getvalue()
+        return self._init_buffer().getvalue()
 
     def __del__(self):
         """Ensure cleanup on garbage collection."""

--- a/src/pythermondt/io/utils.py
+++ b/src/pythermondt/io/utils.py
@@ -100,7 +100,7 @@ class IOPathWrapper:
         return self._init_buffer().write(data)
 
     def read(self, size: int = -1) -> bytes:
-        """Read up to size bytes from the beginning of the buffer.
+        """Read up to size bytes from the current buffer position.
 
         Args:
             size: Number of bytes to read (default: -1 reads all).
@@ -108,7 +108,7 @@ class IOPathWrapper:
         Returns:
             Bytes read from the buffer.
         """
-        return self.file_obj.read(size)
+        return self._init_buffer().read(size)
 
     def getvalue(self) -> bytes:
         """Return the current contents of the internal buffer as bytes."""

--- a/src/pythermondt/io/utils.py
+++ b/src/pythermondt/io/utils.py
@@ -99,6 +99,17 @@ class IOPathWrapper:
             data = data.encode()
         return self._init_buffer().write(data)
 
+    def read(self, size: int = -1) -> bytes:
+        """Read up to size bytes from the beginning of the buffer.
+
+        Args:
+            size: Number of bytes to read (default: -1 reads all).
+
+        Returns:
+            Bytes read from the buffer.
+        """
+        return self.file_obj.read(size)
+
     def getvalue(self) -> bytes:
         """Return the current contents of the internal buffer as bytes."""
         return self._init_buffer().getvalue()

--- a/src/pythermondt/io/utils.py
+++ b/src/pythermondt/io/utils.py
@@ -2,22 +2,25 @@ import logging
 import os
 import tempfile
 from io import BytesIO
+from typing import TypeAlias
 
 logger = logging.getLogger(__name__)
+
+IOPathSource: TypeAlias = str | BytesIO | bytes | None
 
 
 class IOPathWrapper:
     """Provides unified access to file content via both path and buffer interfaces."""
 
-    def __init__(self, source: str | BytesIO | bytes):
+    def __init__(self, source: IOPathSource = None):
         """Provides unified access to file content via both path and buffer interfaces.
 
-        Initialize with either a file path or file content.
+        Initialize with a file path, file content, or an empty writable buffer.
 
         Args:
-            source: Either a file path (str), file-like object, or bytes
+            source: A file path (str), file-like object, bytes, or None for an empty writable buffer.
         """
-        self.__source = source
+        self.__source: IOPathSource = BytesIO() if source is None else source
         self.__file_obj: BytesIO | None = None
         self.__temp_path: str | None = None
 
@@ -71,6 +74,35 @@ class IOPathWrapper:
                     exc_info=True,  # Include traceback for debugging
                 )
             self.__temp_path = None
+
+    def __enter__(self) -> "IOPathWrapper":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def write(self, data: str | bytes) -> int:
+        """Write data to the internal buffer.
+
+        Args:
+            data: Data to write. Strings are encoded to UTF-8 bytes.
+
+        Returns:
+            Number of bytes written.
+        """
+        if isinstance(data, str):
+            data = data.encode()
+        if self.__file_obj is None:
+            _ = self.file_obj
+        assert self.__file_obj is not None
+        return self.__file_obj.write(data)
+
+    def getvalue(self) -> bytes:
+        """Return the current contents of the internal buffer as bytes."""
+        if self.__file_obj is None:
+            _ = self.file_obj
+        assert self.__file_obj is not None
+        return self.__file_obj.getvalue()
 
     def __del__(self):
         """Ensure cleanup on garbage collection."""

--- a/tests/io/test_iopathwrapper.py
+++ b/tests/io/test_iopathwrapper.py
@@ -1,5 +1,6 @@
 """Tests for IOPathWrapper edge cases."""
 
+import json
 import os
 from io import BytesIO
 from re import escape
@@ -10,7 +11,7 @@ from pytest import FixtureRequest, MonkeyPatch
 from pythermondt.io.utils import IOPathWrapper
 
 
-@pytest.fixture(params=[None, 12345, [1, 2, 3], {"key": "value"}, 3.14], ids=lambda x: f"invalid_value={x!r}")
+@pytest.fixture(params=[12345, [1, 2, 3], {"key": "value"}, 3.14], ids=lambda x: f"invalid_value={x!r}")
 def invalid_values(request: FixtureRequest):
     """Fixture that provides invalid values for testing."""
     return request.param
@@ -88,4 +89,93 @@ def test_close_removes_temp_file():
     assert os.path.exists(temp_path)
 
     wrapper.close()
+    assert not os.path.exists(temp_path)
+
+
+def test_default_constructor_creates_writable_buffer():
+    """Test that IOPathWrapper() creates an empty, writable buffer."""
+    wrapper = IOPathWrapper()
+    assert wrapper.getvalue() == b""
+
+    wrapper.write(b"hello")
+    assert wrapper.getvalue() == b"hello"
+
+
+def test_context_manager_calls_close():
+    """Test that __exit__ calls close() and removes temp files."""
+    wrapper = IOPathWrapper(b"content")
+    temp_path = wrapper.file_path
+    assert os.path.exists(temp_path)
+
+    with wrapper as f:
+        assert f is wrapper
+        assert f.getvalue() == b"content"
+
+    assert not os.path.exists(temp_path)
+
+
+def test_write_with_str_encodes_to_bytes():
+    """Test that write() encodes str input to UTF-8 bytes."""
+    wrapper = IOPathWrapper()
+    n = wrapper.write("héllo")
+    assert n == 6  # é is 2 bytes in UTF-8
+    assert wrapper.getvalue() == "héllo".encode()
+
+
+def test_write_returns_byte_count_for_bytes_input():
+    """Test that write() returns the number of bytes written."""
+    wrapper = IOPathWrapper()
+    n = wrapper.write(b"abc")
+    assert n == 3
+    assert wrapper.getvalue() == b"abc"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("bytes", b"hello from bytes"),
+        ("bytesio", b"hello from BytesIO"),
+        ("path", b"hello from file"),
+    ],
+    ids=["bytes", "bytesio", "path"],
+)
+def test_getvalue_on_source_types(source, expected, tmp_path):
+    """Test that getvalue() returns buffer content for each source type."""
+    match source:
+        case "path":
+            p = tmp_path / "test.txt"
+            p.write_bytes(expected)
+            src = str(p)
+        case "bytes":
+            src = expected
+        case "bytesio":
+            src = BytesIO(expected)
+
+    wrapper = IOPathWrapper(src)
+    assert wrapper.getvalue() == expected
+
+
+def test_json_dump_integration():
+    """Test full json.dump → getvalue → upload-like write pattern."""
+    results = {"key": "value", "count": 42}
+
+    with IOPathWrapper() as f:
+        json.dump(results, f)
+        content = f.getvalue()
+
+    assert json.loads(content) == results
+
+
+def test_context_manager_cleans_up_on_exception():
+    """Test that __exit__ calls close() even when an exception occurs."""
+    wrapper = IOPathWrapper(b"content")
+    temp_path = wrapper.file_path
+    assert os.path.exists(temp_path)
+
+    try:
+        with wrapper:
+            raise RuntimeError("simulated failure")
+    except RuntimeError:
+        pass
+
     assert not os.path.exists(temp_path)

--- a/tests/io/test_iopathwrapper.py
+++ b/tests/io/test_iopathwrapper.py
@@ -93,7 +93,7 @@ def test_close_removes_temp_file():
 
 
 def test_default_constructor_creates_writable_buffer():
-    """Test that IOPathWrapper() creates an empty, writable buffer."""
+    """Default-constructed wrapper starts as an empty writable buffer."""
     wrapper = IOPathWrapper()
     assert wrapper.getvalue() == b""
 
@@ -102,7 +102,7 @@ def test_default_constructor_creates_writable_buffer():
 
 
 def test_context_manager_calls_close():
-    """Test that __exit__ calls close() and removes temp files."""
+    """Context manager cleans up temp files on normal exit."""
     wrapper = IOPathWrapper(b"content")
     temp_path = wrapper.file_path
     assert os.path.exists(temp_path)
@@ -115,7 +115,7 @@ def test_context_manager_calls_close():
 
 
 def test_write_with_str_encodes_to_bytes():
-    """Test that write() encodes str input to UTF-8 bytes."""
+    """write() accepts str, encodes to UTF-8, and returns byte count."""
     wrapper = IOPathWrapper()
     n = wrapper.write("héllo")
     assert n == 6  # é is 2 bytes in UTF-8
@@ -123,11 +123,19 @@ def test_write_with_str_encodes_to_bytes():
 
 
 def test_write_returns_byte_count_for_bytes_input():
-    """Test that write() returns the number of bytes written."""
+    """write() with bytes input returns the number of bytes written."""
     wrapper = IOPathWrapper()
     n = wrapper.write(b"abc")
     assert n == 3
     assert wrapper.getvalue() == b"abc"
+
+
+def test_sequential_writes_accumulate():
+    """Multiple write calls append without overwriting previous content."""
+    wrapper = IOPathWrapper()
+    wrapper.write(b"hello")
+    wrapper.write(b" world")
+    assert wrapper.getvalue() == b"hello world"
 
 
 @pytest.mark.parametrize(
@@ -140,7 +148,8 @@ def test_write_returns_byte_count_for_bytes_input():
     ids=["bytes", "bytesio", "path"],
 )
 def test_getvalue_on_source_types(source, expected, tmp_path):
-    """Test that getvalue() returns buffer content for each source type."""
+    """getvalue() returns buffer content for path, bytes, and BytesIO sources."""
+    src: str | bytes | BytesIO
     match source:
         case "path":
             p = tmp_path / "test.txt"
@@ -156,7 +165,7 @@ def test_getvalue_on_source_types(source, expected, tmp_path):
 
 
 def test_json_dump_integration():
-    """Test full json.dump → getvalue → upload-like write pattern."""
+    """json.dump writes JSON to the wrapper and getvalue returns valid parseable JSON."""
     results = {"key": "value", "count": 42}
 
     with IOPathWrapper() as f:
@@ -167,7 +176,7 @@ def test_json_dump_integration():
 
 
 def test_context_manager_cleans_up_on_exception():
-    """Test that __exit__ calls close() even when an exception occurs."""
+    """Context manager cleans up temp files even when an exception propagates."""
     wrapper = IOPathWrapper(b"content")
     temp_path = wrapper.file_path
     assert os.path.exists(temp_path)

--- a/tests/io/test_iopathwrapper.py
+++ b/tests/io/test_iopathwrapper.py
@@ -150,6 +150,14 @@ def test_read_with_size_returns_requested_bytes():
     assert wrapper.read(3) == b"abc"
 
 
+def test_read_with_size_advances_position():
+    """Repeated read(n) calls advance through the buffer."""
+    wrapper = IOPathWrapper(b"abcdef")
+    assert wrapper.read(3) == b"abc"
+    assert wrapper.read(3) == b"def"
+    assert wrapper.read(3) == b""
+
+
 def test_json_load_integration():
     """json.load calls read() so the wrapper works as a drop-in file object."""
     wrapper = IOPathWrapper(b'{"test": "data"}')

--- a/tests/io/test_iopathwrapper.py
+++ b/tests/io/test_iopathwrapper.py
@@ -138,6 +138,24 @@ def test_sequential_writes_accumulate():
     assert wrapper.getvalue() == b"hello world"
 
 
+def test_read_returns_full_content():
+    """read() returns the entire buffer content."""
+    wrapper = IOPathWrapper(b"test binary data")
+    assert wrapper.read() == b"test binary data"
+
+
+def test_read_with_size_returns_requested_bytes():
+    """read(n) returns at most n bytes."""
+    wrapper = IOPathWrapper(b"abcdef")
+    assert wrapper.read(3) == b"abc"
+
+
+def test_json_load_integration():
+    """json.load calls read() so the wrapper works as a drop-in file object."""
+    wrapper = IOPathWrapper(b'{"test": "data"}')
+    assert json.load(wrapper) == {"test": "data"}
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [


### PR DESCRIPTION
- Extract `_init_buffer()` to lazy-init the buffer without seeking, fixing write/getvalue position corruption
- Add `write()`, `read()`, and `getvalue()` methods for full read-write file-like access
- Add `__enter__`/`__exit__` context manager with temp file cleanup
- Allow default constructor to create an empty writable buffer
- Add tests for sequential writes, partial reads, json.load/dump integration, and context manager cleanup on exception

Makes IOPathWrapper a correct file-like object usable in read-write workflows.