### PR TITLE
Pin setuptools>=83 for PEP 639 license support and CVE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ Releases = "https://github.com/voidsy-gmbh/pyThermoNDT/releases"
 
 # Config for the build system
 [build-system]
-requires = ["setuptools>=66.0"]
+requires = ["setuptools>=78.1.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ Releases = "https://github.com/voidsy-gmbh/pyThermoNDT/releases"
 
 # Config for the build system
 [build-system]
-requires = ["setuptools>=78.1.1"]
+requires = ["setuptools>=83.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
- Raise minimum setuptools from 66.0 to 83 in `[build-system].requires` to fix build failures when the PEP 639 SPDX license string `license = "Apache-2.0"` is validated against pre-77 setuptools
- Floor the pin at 83 to cover CVE-2025-47273 (path traversal in `PackageIndex.download`, fixed in 78.1.1) and CVE-2026-59890 (MANIFEST.in exclusion bypass via Unicode normalization collision, fixed in 83.0.0)

Single-line `pyproject.toml` change ensuring builds use a setuptools version that supports the project's license format and includes all known security patches.