### PR TITLE
Fix lazy cache pickling failure when DataLoader uses spawn or forkserver

### DIFF
--- a/src/pythermondt/dataset/base_dataset.py
+++ b/src/pythermondt/dataset/base_dataset.py
@@ -53,6 +53,17 @@ class BaseDataset(Dataset, ABC):
         if self.cache_built:
             self.release_cache(gc_collect=False)
 
+    def __getstate__(self):
+        """Exclude the lazy-cache Manager so the dataset can be pickled for DataLoader workers."""
+        state = self.__dict__.copy()
+        # ListProxy is picklable; SyncManager is not (parent keeps ownership / shutdown).
+        state["_BaseDataset__manager"] = None
+        return state
+
+    def __setstate__(self, state: dict):
+        """Restore object from pickled state."""
+        vars(self).update(state)
+
     def __getitem__(self, idx: int) -> DataContainer:
         """Get an item while also applying the proper transform chain.
 
@@ -150,8 +161,12 @@ class BaseDataset(Dataset, ABC):
         - Random transforms + subsequent operations run at runtime
 
         Platform Considerations:
-            **Windows**: Use lazy mode to avoid memory issues due to cache duplication in forked processes
-            **Linux**: Both modes work efficiently - choose based on workflow preference
+            **Windows / spawn**: Prefer lazy mode so workers share one cache via a manager list instead of each
+            holding a full copy after process start.
+            **Linux**: Both modes work efficiently - choose based on workflow preference.
+
+            With lazy mode the parent process owns the manager; DataLoader workers receive only the picklable
+            list proxy. Keep the parent dataset (and its cache) alive for the lifetime of the workers.
 
         Args:
             mode (CacheMode): Cache building strategy

--- a/tests/dataset/test_base_dataset.py
+++ b/tests/dataset/test_base_dataset.py
@@ -1,7 +1,7 @@
 """Tests for BaseDataset behavior exercised through ThermoDataset and IndexedThermoDataset."""
 
 import gc
-import multiprocessing as mp
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,8 +13,12 @@ from pythermondt.dataset import container_collate
 from pythermondt.dataset.base_dataset import CacheMode
 from pythermondt.transforms import ApplyLUT
 
-# Contexts that pickle the dataset into workers (the path broken by lazy Manager state).
-_MP_CONTEXTS = [ctx for ctx in ("spawn", "forkserver") if ctx in mp.get_all_start_methods()]
+# Start methods that pickle the dataset into workers (the #465 path).
+_MP_CONTEXTS_BY_PLATFORM = {
+    "win32": ["spawn"],
+    "darwin": ["spawn"],
+    "linux": ["spawn", "forkserver"],
+}
 
 
 @pytest.mark.parametrize("idx", [0, 1])
@@ -76,7 +80,7 @@ def test_build_cache_invalid_mode(local_reader_three_files: LocalReader):
 
 
 @pytest.mark.parametrize("mode", ["lazy", "immediate"])
-@pytest.mark.parametrize("mp_context", _MP_CONTEXTS)
+@pytest.mark.parametrize("mp_context", _MP_CONTEXTS_BY_PLATFORM[sys.platform])
 @pytest.mark.parametrize("num_workers", [0, 2])
 def test_build_cache_dataloader_multiprocess(
     local_reader_three_files: LocalReader,

--- a/tests/dataset/test_base_dataset.py
+++ b/tests/dataset/test_base_dataset.py
@@ -1,11 +1,20 @@
 """Tests for BaseDataset behavior exercised through ThermoDataset and IndexedThermoDataset."""
 
 import gc
+import multiprocessing as mp
 from unittest.mock import MagicMock
 
 import pytest
+import torch
+from torch.utils.data import DataLoader
 
 from pythermondt import LocalReader, ThermoDataset
+from pythermondt.dataset import container_collate
+from pythermondt.dataset.base_dataset import CacheMode
+from pythermondt.transforms import ApplyLUT
+
+# Contexts that pickle the dataset into workers (the path broken by lazy Manager state).
+_MP_CONTEXTS = [ctx for ctx in ("spawn", "forkserver") if ctx in mp.get_all_start_methods()]
 
 
 @pytest.mark.parametrize("idx", [0, 1])
@@ -64,6 +73,42 @@ def test_build_cache_invalid_mode(local_reader_three_files: LocalReader):
     dataset = ThermoDataset(local_reader_three_files)
     with pytest.raises(ValueError, match="Invalid cache mode"):
         dataset.build_cache(mode="invalid")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("mode", ["lazy", "immediate"])
+@pytest.mark.parametrize("mp_context", _MP_CONTEXTS)
+@pytest.mark.parametrize("num_workers", [0, 2])
+def test_build_cache_dataloader_multiprocess(
+    local_reader_three_files: LocalReader,
+    mode: CacheMode,
+    mp_context: str,
+    num_workers: int,
+):
+    """Regression test for #465: build_cache + DataLoader under pickling start methods."""
+    dataset = ThermoDataset(
+        local_reader_three_files,
+        transform=ApplyLUT(target_dtype=torch.float32),
+    )
+    dataset.build_cache(mode=mode)
+
+    loader = DataLoader(
+        dataset,
+        batch_size=2,
+        shuffle=False,
+        num_workers=num_workers,
+        multiprocessing_context=mp_context if num_workers > 0 else None,
+        collate_fn=container_collate("/Data/Tdata"),
+    )
+
+    # Try and finally for cleanup to ensure cache is released even if the test fails.
+    try:
+        batch = next(iter(loader))
+        assert len(batch) == 1
+        assert batch[0].shape[0] == 2
+    finally:
+        # Drain workers before releasing the cache manager.
+        del loader
+        dataset.release_cache()
 
 
 def test_release_cache_manager_shutdown_exception(local_reader_three_files: LocalReader):


### PR DESCRIPTION
- Add `__getstate__`/`__setstate__` to BaseDataset to exclude the non-picklable `SyncManager` from the pickled state, while keeping the picklable `ListProxy` so workers can still share the lazy cache
- Update `build_cache` docstring to clarify that the parent owns the manager and workers receive only the proxy
- Add a parametrized DataLoader regression test covering both cache modes (`lazy`, `immediate`), both applicable multiprocessing contexts (`spawn`, `forkserver`), and `num_workers` of 0 and 2

Closes #465 — BaseDataset is now picklable after `build_cache("lazy")`, which fixes `TypeError` when using DataLoader with `num_workers > 0` on Windows (spawn) or Python 3.14+ Linux (forkserver).