### PR TITLE
Add items() method to BaseReader for (key, container) pair iteration

### DIFF
--- a/src/pythermondt/readers/__init__.py
+++ b/src/pythermondt/readers/__init__.py
@@ -1,11 +1,14 @@
 from .azure_reader import AzureBlobReader
-from .base_reader import BaseReader
+from .base_reader import BaseReader, ItemsBy, ItemsByEntry, ItemsByPath
 from .local_reader import LocalReader
 from .s3_reader import S3Reader
 
 __all__ = [
     "AzureBlobReader",
     "BaseReader",
+    "ItemsBy",
+    "ItemsByEntry",
+    "ItemsByPath",
     "LocalReader",
     "S3Reader",
 ]

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Iterator
 from functools import partial
 from multiprocessing.pool import ThreadPool
 from threading import Lock
-from typing import Literal, overload
+from typing import Literal, get_args, overload
 from urllib.parse import unquote, urlparse
 
 from pydantic import BaseModel, ConfigDict, RootModel, ValidationError
@@ -20,6 +20,10 @@ from ..io import BaseBackend, FileInfo, IOPathWrapper
 from ..io.parsers import BaseParser, find_parser_for_extension, get_all_supported_extensions
 
 logger = logging.getLogger(__name__)
+
+ItemsByPath = Literal["files", "file_names", "file_uris"]
+ItemsByEntry = Literal["file_entries"]
+ItemsBy = ItemsByPath | ItemsByEntry
 
 
 class ManifestEntry(BaseModel):
@@ -279,45 +283,36 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
             yield self.read_file(uri)
 
     @overload
-    def items(
-        self, by: Literal["files", "file_names", "file_uris"] = "files", reverse: bool = False
-    ) -> Iterator[tuple[str, DataContainer]]: ...
+    def items(self, by: ItemsByPath = "files", reverse: bool = False) -> Iterator[tuple[str, DataContainer]]: ...
 
     @overload
-    def items(self, by: Literal["file_entries"], reverse: bool = False) -> Iterator[tuple[FileInfo, DataContainer]]: ...
+    def items(self, by: ItemsByEntry, reverse: bool = False) -> Iterator[tuple[FileInfo, DataContainer]]: ...
 
-    def items(self, by: str = "files", reverse: bool = False) -> Iterator[tuple[str | FileInfo, DataContainer]]:
+    def items(self, by: ItemsBy = "files", reverse: bool = False) -> Iterator[tuple[str | FileInfo, DataContainer]]:
         """Iterate over ``(key, container)`` pairs.
 
-        Snapshot both the key list and file URIs for consistency, using the
-        existing property caching logic.  This replaces the common pattern::
-
-            for name, container in zip(reader.file_names, reader, strict=True):
-                ...
-
-        with the simpler::
-
-            for name, container in reader.items(by="file_names"):
-                ...
+        Snapshots the selected key list and file URIs together for consistency.
 
         Args:
-            by: Which identifier to pair with each container.
-                ``"files"`` (default) — decoded full path.
-                ``"file_names"`` — basename only.
-                ``"file_uris"`` — URI-encoded path.
-                ``"file_entries"`` — :class:`FileInfo` metadata object.
-            reverse: When ``True``, iterate in reverse order.
+            by (ItemsBy, optional): Identifier paired with each container.
+                ``ItemsByPath`` values (``"files"``, ``"file_names"``, ``"file_uris"``) yield ``str`` keys.
+                ``ItemsByEntry`` (``"file_entries"``) yields :class:`FileInfo` keys.
+                Default is ``"files"`` (decoded full path).
+            reverse (bool, optional): Iterate in reverse order. Default is ``False``.
 
         Yields:
-            ``(key, container)`` tuples.
+            ``(key, container)`` tuples. Key type depends on ``by`` (see Args).
+
+        Raises:
+            ValueError: If ``by`` is not a supported :data:`ItemsBy` identifier.
         """
-        if by not in ("files", "file_names", "file_uris", "file_entries"):
+        if by not in get_args(ItemsByPath) + get_args(ItemsByEntry):
             raise ValueError(
-                f"Invalid 'by' value: {by!r}. Must be one of 'files', 'file_names', 'file_uris', 'file_entries'."
+                f"Invalid 'by' value: {by!r}. Must be one of {get_args(ItemsByPath) + get_args(ItemsByEntry)}."
             )
 
+        # Snapshot both lists once so keys and containers stay paired if cache_files is off.
         uris = self.file_uris
-
         if by == "file_entries":
             keys: list[str] | list[FileInfo] = self.file_entries
         elif by == "file_uris":
@@ -327,13 +322,12 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         else:
             keys = self.files
 
-        file_count = len(uris)
+        pairs: list[tuple[str | FileInfo, str]] = list(zip(keys, uris, strict=True))
         if reverse:
-            for i in range(file_count - 1, -1, -1):
-                yield keys[i], self.read_file(uris[i])
-        else:
-            for i in range(file_count):
-                yield keys[i], self.read_file(uris[i])
+            pairs.reverse()
+
+        for key, uri in pairs:
+            yield key, self.read_file(uri)
 
     def _to_file_name(self, file_path: str) -> str:
         """Extract the file name from a file path."""

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -322,11 +322,13 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         else:
             keys = self.files
 
-        pairs: list[tuple[str | FileInfo, str]] = list(zip(keys, uris, strict=True))
+        key_uri_pairs: Iterator[tuple[str | FileInfo, str]]
         if reverse:
-            pairs.reverse()
+            key_uri_pairs = zip(reversed(keys), reversed(uris), strict=True)
+        else:
+            key_uri_pairs = zip(keys, uris, strict=True)
 
-        for key, uri in pairs:
+        for key, uri in key_uri_pairs:
             yield key, self.read_file(uri)
 
     def _to_file_name(self, file_path: str) -> str:

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -292,20 +292,20 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
     def items(self, by: ItemsBy = "files", reverse: bool = False) -> Iterator[tuple[str | FileInfo, DataContainer]]:
         """Iterate over ``(key, container)`` pairs.
 
-        Snapshots the selected key list and file URIs together for consistency.
+        ``by`` selects the key source (``files``, ``file_names``, ``file_uris``, or
+        ``file_entries``). Keys and file URIs are snapshotted together so pairs stay
+        consistent when ``cache_files`` is off.
 
         Args:
-            by (ItemsBy, optional): Identifier paired with each container.
-                ``ItemsByPath`` values (``"files"``, ``"file_names"``, ``"file_uris"``) yield ``str`` keys.
-                ``ItemsByEntry`` (``"file_entries"``) yields :class:`FileInfo` keys.
-                Default is ``"files"`` (decoded full path).
+            by (ItemsBy, optional): Key source. Default is ``"files"``.
             reverse (bool, optional): Iterate in reverse order. Default is ``False``.
 
         Yields:
-            ``(key, container)`` tuples. Key type depends on ``by`` (see Args).
+            tuple: ``(key, DataContainer)`` where ``key`` is ``str`` or :class:`FileInfo`
+                depending on ``by``.
 
         Raises:
-            ValueError: If ``by`` is not a supported :data:`ItemsBy` identifier.
+            ValueError: If ``by`` is not a supported identifier.
         """
         if by not in _ITEMS_BY_VALUES:
             raise ValueError(f"Invalid 'by' value: {by!r}. Must be one of {_ITEMS_BY_VALUES}.")

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -8,6 +8,7 @@ from collections.abc import Callable, Iterator
 from functools import partial
 from multiprocessing.pool import ThreadPool
 from threading import Lock
+from typing import Literal, overload
 from urllib.parse import unquote, urlparse
 
 from pydantic import BaseModel, ConfigDict, RootModel, ValidationError
@@ -276,6 +277,63 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
 
         for uri in reversed(file_uris):
             yield self.read_file(uri)
+
+    @overload
+    def items(
+        self, by: Literal["files", "file_names", "file_uris"] = "files", reverse: bool = False
+    ) -> Iterator[tuple[str, DataContainer]]: ...
+
+    @overload
+    def items(self, by: Literal["file_entries"], reverse: bool = False) -> Iterator[tuple[FileInfo, DataContainer]]: ...
+
+    def items(self, by: str = "files", reverse: bool = False) -> Iterator[tuple[str | FileInfo, DataContainer]]:
+        """Iterate over ``(key, container)`` pairs.
+
+        Snapshot both the key list and file URIs for consistency, using the
+        existing property caching logic.  This replaces the common pattern::
+
+            for name, container in zip(reader.file_names, reader, strict=True):
+                ...
+
+        with the simpler::
+
+            for name, container in reader.items(by="file_names"):
+                ...
+
+        Args:
+            by: Which identifier to pair with each container.
+                ``"files"`` (default) — decoded full path.
+                ``"file_names"`` — basename only.
+                ``"file_uris"`` — URI-encoded path.
+                ``"file_entries"`` — :class:`FileInfo` metadata object.
+            reverse: When ``True``, iterate in reverse order.
+
+        Yields:
+            ``(key, container)`` tuples.
+        """
+        if by not in ("files", "file_names", "file_uris", "file_entries"):
+            raise ValueError(
+                f"Invalid 'by' value: {by!r}. Must be one of 'files', 'file_names', 'file_uris', 'file_entries'."
+            )
+
+        uris = self.file_uris
+
+        if by == "file_entries":
+            keys: list[str] | list[FileInfo] = self.file_entries
+        elif by == "file_uris":
+            keys = uris
+        elif by == "file_names":
+            keys = self.file_names
+        else:
+            keys = self.files
+
+        file_count = len(uris)
+        if reverse:
+            for i in range(file_count - 1, -1, -1):
+                yield keys[i], self.read_file(uris[i])
+        else:
+            for i in range(file_count):
+                yield keys[i], self.read_file(uris[i])
 
     def _to_file_name(self, file_path: str) -> str:
         """Extract the file name from a file path."""

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -307,25 +307,23 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         Raises:
             ValueError: If ``by`` is not a supported identifier.
         """
-        if by not in _ITEMS_BY_VALUES:
-            raise ValueError(f"Invalid 'by' value: {by!r}. Must be one of {_ITEMS_BY_VALUES}.")
-
         # Single snapshot so keys and URIs stay paired when cache_files is off.
-        if by == "file_entries":
-            entries = self.file_entries
-            uris = [entry.path for entry in entries]
-            keys: list[str] | list[FileInfo] = entries
-        else:
-            uris = list(self.file_uris)
-            if by == "file_uris":
-                keys = uris
-            elif by == "file_names":
+        keys: list[str] | list[FileInfo]
+        match by:
+            case "file_entries":
+                keys = list(self.file_entries)
+                uris = [entry.path for entry in keys]
+            case "file_uris":
+                keys = uris = list(self.file_uris)
+            case "file_names":
+                uris = list(self.file_uris)
                 keys = [self._to_file_name(uri) for uri in uris]
-            elif self.backend.scheme != "file":
+            case "files":
+                uris = list(self.file_uris)
                 # Match files property: only decode file:// URIs.
-                keys = uris
-            else:
-                keys = [unquote(uri) for uri in uris]
+                keys = uris if self.backend.scheme != "file" else [unquote(uri) for uri in uris]
+            case _:
+                raise ValueError(f"Invalid 'by' value: {by!r}. Must be one of {_ITEMS_BY_VALUES}.")
 
         # Build Iterator based on requested order
         key_uri_pairs: Iterator[tuple[str | FileInfo, str]]

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -310,16 +310,22 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         if by not in _ITEMS_BY_VALUES:
             raise ValueError(f"Invalid 'by' value: {by!r}. Must be one of {_ITEMS_BY_VALUES}.")
 
-        # Snapshot both lists once so keys and containers stay paired if cache_files is off.
-        uris = self.file_uris
+        # Single snapshot so keys and URIs stay paired when cache_files is off.
         if by == "file_entries":
-            keys: list[str] | list[FileInfo] = self.file_entries
-        elif by == "file_uris":
-            keys = uris
-        elif by == "file_names":
-            keys = self.file_names
+            entries = self.file_entries
+            uris = [entry.path for entry in entries]
+            keys: list[str] | list[FileInfo] = entries
         else:
-            keys = self.files
+            uris = list(self.file_uris)
+            if by == "file_uris":
+                keys = uris
+            elif by == "file_names":
+                keys = [self._to_file_name(uri) for uri in uris]
+            elif self.backend.scheme != "file":
+                # Match files property: only decode file:// URIs.
+                keys = uris
+            else:
+                keys = [unquote(uri) for uri in uris]
 
         # Build Iterator based on requested order
         key_uri_pairs: Iterator[tuple[str | FileInfo, str]]

--- a/src/pythermondt/readers/base_reader.py
+++ b/src/pythermondt/readers/base_reader.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 ItemsByPath = Literal["files", "file_names", "file_uris"]
 ItemsByEntry = Literal["file_entries"]
+_ITEMS_BY_VALUES = get_args(ItemsByPath) + get_args(ItemsByEntry)
 ItemsBy = ItemsByPath | ItemsByEntry
 
 
@@ -306,10 +307,8 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         Raises:
             ValueError: If ``by`` is not a supported :data:`ItemsBy` identifier.
         """
-        if by not in get_args(ItemsByPath) + get_args(ItemsByEntry):
-            raise ValueError(
-                f"Invalid 'by' value: {by!r}. Must be one of {get_args(ItemsByPath) + get_args(ItemsByEntry)}."
-            )
+        if by not in _ITEMS_BY_VALUES:
+            raise ValueError(f"Invalid 'by' value: {by!r}. Must be one of {_ITEMS_BY_VALUES}.")
 
         # Snapshot both lists once so keys and containers stay paired if cache_files is off.
         uris = self.file_uris
@@ -322,6 +321,7 @@ class BaseReader(ABC):  # pylint: disable=too-many-instance-attributes
         else:
             keys = self.files
 
+        # Build Iterator based on requested order
         key_uri_pairs: Iterator[tuple[str | FileInfo, str]]
         if reverse:
             key_uri_pairs = zip(reversed(keys), reversed(uris), strict=True)

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -170,6 +170,20 @@ def test_items_invalid_by(reader_test_data: ReaderTestData):
         list(reader_test_data.reader.items(by="bogus"))  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize("by", ["files", "file_names", "file_uris", "file_entries"])
+def test_items_with_cache_files_false(reader_config: ReaderTestContext, by: ItemsBy):
+    """items() works with cache_files=False and keeps key/container pairs consistent."""
+    reader_config.prepare_file("sample1.test", b"payload1")
+    reader_config.prepare_file("sample2.test", b"payload2")
+    reader = reader_config.make_reader(cache_files=False)
+
+    pairs = list(reader.items(by=by))
+    expected_keys = getattr(reader, by)
+
+    assert [key for key, _ in pairs] == list(expected_keys)
+    assert [_assert_payload(container) for _, container in pairs] == ["payload1", "payload2"]
+
+
 def test_read_file_uses_explicit_parser(reader_test_data: ReaderTestData):
     """Test that read_file delegates parsing to the configured parser."""
     container = reader_test_data.reader.read_file(reader_test_data.files["sample1.test"])

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -127,6 +127,70 @@ def test_reversed(reader_test_data: ReaderTestData):
     assert payloads == [reader_test_data.contents["sample2.test"], reader_test_data.contents["sample1.test"]]
 
 
+def test_items_default(reader_test_data: ReaderTestData):
+    """Test items() with default by='files' yields (decoded_path, container) pairs in reader order."""
+    pairs = list(reader_test_data.reader.items())
+
+    assert len(pairs) == 2
+    for key, _ in pairs:
+        assert isinstance(key, str)
+
+    payloads = [_assert_payload(c) for _, c in pairs]
+    assert payloads == [reader_test_data.contents["sample1.test"], reader_test_data.contents["sample2.test"]]
+
+
+@pytest.mark.parametrize("by", ["file_names", "file_uris", "files"])
+def test_items_by_mode(reader_test_data: ReaderTestData, by: str):
+    """Test items() with each string key mode yields the expected key type and payloads."""
+    pairs = list(reader_test_data.reader.items(by=by))
+
+    assert len(pairs) == 2
+    for key, _ in pairs:
+        assert isinstance(key, str)
+
+    expected_payloads = [
+        reader_test_data.contents["sample1.test"],
+        reader_test_data.contents["sample2.test"],
+    ]
+    for (_key, container), expected in zip(pairs, expected_payloads, strict=True):
+        assert _assert_payload(container) == expected
+
+    # file_names keys are basenames (no path separators).
+    if by == "file_names":
+        for key, _ in pairs:
+            assert "/" not in key
+            assert "\\" not in key
+            assert key.endswith(".test")
+
+
+def test_items_by_file_entries(reader_test_data: ReaderTestData):
+    """Test items(by='file_entries') yields FileInfo objects with correct paths."""
+    pairs = list(reader_test_data.reader.items(by="file_entries"))
+
+    assert len(pairs) == 2
+    for key, _ in pairs:
+        assert isinstance(key, FileInfo)
+        assert isinstance(key.path, str)
+
+    payloads = [_assert_payload(c) for _, c in pairs]
+    assert payloads == [reader_test_data.contents["sample1.test"], reader_test_data.contents["sample2.test"]]
+
+
+def test_items_reverse(reader_test_data: ReaderTestData):
+    """Test items(reverse=True) yields pairs in reverse reader order."""
+    pairs = list(reader_test_data.reader.items(reverse=True))
+
+    assert len(pairs) == 2
+    payloads = [_assert_payload(c) for _, c in pairs]
+    assert payloads == [reader_test_data.contents["sample2.test"], reader_test_data.contents["sample1.test"]]
+
+
+def test_items_invalid_by(reader_test_data: ReaderTestData):
+    """Test items() raises ValueError for an invalid 'by' value."""
+    with pytest.raises(ValueError, match=escape("Invalid 'by' value: 'bogus'")):
+        list(reader_test_data.reader.items(by="bogus"))
+
+
 def test_read_file_uses_explicit_parser(reader_test_data: ReaderTestData):
     """Test that read_file delegates parsing to the configured parser."""
     container = reader_test_data.reader.read_file(reader_test_data.files["sample1.test"])

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -6,7 +6,7 @@ import pytest
 
 from pythermondt.data import DataContainer
 from pythermondt.io import FileInfo
-from pythermondt.readers.base_reader import BaseReader, ItemsBy
+from pythermondt.readers import BaseReader, ItemsBy
 from tests.reader.conftest import ReaderTestContext, ReaderTestData
 from tests.support.storage import PlainTextParser
 
@@ -144,7 +144,14 @@ def test_items_keys_match_properties(reader_test_data: ReaderTestData, by: Items
 def test_items_default_uses_files(reader_test_data: ReaderTestData):
     """Test items() defaults to by='files'."""
     reader = reader_test_data.reader
-    assert [key for key, _ in reader.items()] == list(reader.files)
+    assert list(reader.items()) == list(reader.items(by="files"))
+
+
+def test_items_pairs_key_to_container(reader_test_data: ReaderTestData):
+    """Test each items() key maps to the container for that file."""
+    reader = reader_test_data.reader
+    for name, container in reader.items(by="file_names"):
+        assert _assert_payload(container) == reader_test_data.contents[name]
 
 
 def test_items_reverse(reader_test_data: ReaderTestData):
@@ -153,10 +160,8 @@ def test_items_reverse(reader_test_data: ReaderTestData):
     pairs = list(reader.items(by="file_names", reverse=True))
 
     assert [key for key, _ in pairs] == list(reversed(reader.file_names))
-    assert [_assert_payload(container) for _, container in pairs] == [
-        reader_test_data.contents["sample2.test"],
-        reader_test_data.contents["sample1.test"],
-    ]
+    for name, container in pairs:
+        assert _assert_payload(container) == reader_test_data.contents[name]
 
 
 def test_items_invalid_by(reader_test_data: ReaderTestData):

--- a/tests/reader/test_reader_interface.py
+++ b/tests/reader/test_reader_interface.py
@@ -6,7 +6,7 @@ import pytest
 
 from pythermondt.data import DataContainer
 from pythermondt.io import FileInfo
-from pythermondt.readers import BaseReader
+from pythermondt.readers.base_reader import BaseReader, ItemsBy
 from tests.reader.conftest import ReaderTestContext, ReaderTestData
 from tests.support.storage import PlainTextParser
 
@@ -127,68 +127,42 @@ def test_reversed(reader_test_data: ReaderTestData):
     assert payloads == [reader_test_data.contents["sample2.test"], reader_test_data.contents["sample1.test"]]
 
 
-def test_items_default(reader_test_data: ReaderTestData):
-    """Test items() with default by='files' yields (decoded_path, container) pairs in reader order."""
-    pairs = list(reader_test_data.reader.items())
+@pytest.mark.parametrize("by", ["files", "file_names", "file_uris", "file_entries"])
+def test_items_keys_match_properties(reader_test_data: ReaderTestData, by: ItemsBy):
+    """Test items() keys match the corresponding reader property and payloads stay in order."""
+    reader = reader_test_data.reader
+    pairs = list(reader.items(by=by))
+    expected_keys = getattr(reader, by)
 
-    assert len(pairs) == 2
-    for key, _ in pairs:
-        assert isinstance(key, str)
-
-    payloads = [_assert_payload(c) for _, c in pairs]
-    assert payloads == [reader_test_data.contents["sample1.test"], reader_test_data.contents["sample2.test"]]
-
-
-@pytest.mark.parametrize("by", ["file_names", "file_uris", "files"])
-def test_items_by_mode(reader_test_data: ReaderTestData, by: str):
-    """Test items() with each string key mode yields the expected key type and payloads."""
-    pairs = list(reader_test_data.reader.items(by=by))
-
-    assert len(pairs) == 2
-    for key, _ in pairs:
-        assert isinstance(key, str)
-
-    expected_payloads = [
+    assert [key for key, _ in pairs] == list(expected_keys)
+    assert [_assert_payload(container) for _, container in pairs] == [
         reader_test_data.contents["sample1.test"],
         reader_test_data.contents["sample2.test"],
     ]
-    for (_key, container), expected in zip(pairs, expected_payloads, strict=True):
-        assert _assert_payload(container) == expected
-
-    # file_names keys are basenames (no path separators).
-    if by == "file_names":
-        for key, _ in pairs:
-            assert "/" not in key
-            assert "\\" not in key
-            assert key.endswith(".test")
 
 
-def test_items_by_file_entries(reader_test_data: ReaderTestData):
-    """Test items(by='file_entries') yields FileInfo objects with correct paths."""
-    pairs = list(reader_test_data.reader.items(by="file_entries"))
-
-    assert len(pairs) == 2
-    for key, _ in pairs:
-        assert isinstance(key, FileInfo)
-        assert isinstance(key.path, str)
-
-    payloads = [_assert_payload(c) for _, c in pairs]
-    assert payloads == [reader_test_data.contents["sample1.test"], reader_test_data.contents["sample2.test"]]
+def test_items_default_uses_files(reader_test_data: ReaderTestData):
+    """Test items() defaults to by='files'."""
+    reader = reader_test_data.reader
+    assert [key for key, _ in reader.items()] == list(reader.files)
 
 
 def test_items_reverse(reader_test_data: ReaderTestData):
     """Test items(reverse=True) yields pairs in reverse reader order."""
-    pairs = list(reader_test_data.reader.items(reverse=True))
+    reader = reader_test_data.reader
+    pairs = list(reader.items(by="file_names", reverse=True))
 
-    assert len(pairs) == 2
-    payloads = [_assert_payload(c) for _, c in pairs]
-    assert payloads == [reader_test_data.contents["sample2.test"], reader_test_data.contents["sample1.test"]]
+    assert [key for key, _ in pairs] == list(reversed(reader.file_names))
+    assert [_assert_payload(container) for _, container in pairs] == [
+        reader_test_data.contents["sample2.test"],
+        reader_test_data.contents["sample1.test"],
+    ]
 
 
 def test_items_invalid_by(reader_test_data: ReaderTestData):
     """Test items() raises ValueError for an invalid 'by' value."""
     with pytest.raises(ValueError, match=escape("Invalid 'by' value: 'bogus'")):
-        list(reader_test_data.reader.items(by="bogus"))
+        list(reader_test_data.reader.items(by="bogus"))  # type: ignore[arg-type]
 
 
 def test_read_file_uses_explicit_parser(reader_test_data: ReaderTestData):


### PR DESCRIPTION
- Add `BaseReader.items()` method that yields `(key, container)` pairs, supporting four key modes via the `by` parameter: `"files"`, `"file_names"`, `"file_uris"`, and `"file_entries"`
- Define `ItemsByPath` (`Literal["files", "file_names", "file_uris"]`), `ItemsByEntry` (`Literal["file_entries"]`), and `ItemsBy` union type aliases, exported from `pythermondt.readers`
- Use `@overload` signatures so callers get correct return types (`str` keys for path modes, `FileInfo` keys for entry mode)
- Snapshot keys and URIs together at iteration start to keep pairs consistent when `cache_files` is off; support `reverse` parameter for reverse-order traversal
- Add comprehensive tests covering all modes, default behavior, key-container pairing, reverse order, and invalid `by` values

This gives consumers a single, typed method to iterate over all reader data instead of manually composing `files`/`file_names`/`file_uris`/`file_entries` with `read_file()` calls.