### PR TITLE
Make ExcitationSignal optional in SelectFrames and SelectFrameRange

### DIFF
--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -9,6 +9,11 @@ from .base import ThermoTransform
 from .utils import _get_optional_dataset
 
 
+def _remove_time_shift(domain_values: Tensor) -> Tensor:
+    """Remove the time shift in domain values by subtracting the first time step."""
+    return domain_values - domain_values[0]
+
+
 class SelectFrames(ThermoTransform):
     """Select a subset of frames from the data container specified by a single index or a list of indices."""
 
@@ -40,8 +45,9 @@ class SelectFrames(ThermoTransform):
         if has_excitation_signal and excitation_signal:
             excitation_signal = excitation_signal[..., self.frame_indices]
 
-        # Fix time shift in domain values by subtracting the first time step
-        domain_values = _maybe_zero_base_domain(container, domain_values)
+        # Fix time shift in domain values by subtracting the first time step if we are in time domain
+        if container.get_unit("/MetaData/DomainValues").quantity == "time":
+            domain_values = _remove_time_shift(domain_values)
 
         # Update Container and return
         # pylint: disable=duplicate-code
@@ -95,8 +101,9 @@ class SelectFrameRange(ThermoTransform):
         if has_excitation_signal and excitation_signal:
             excitation_signal = excitation_signal[..., start:end]
 
-        # Fix time shift in domain values by subtracting the first time step
-        domain_values = _maybe_zero_base_domain(container, domain_values)
+        # Fix time shift in domain values by subtracting the first time step if we are in time domain
+        if container.get_unit("/MetaData/DomainValues").quantity == "time":
+            domain_values = _remove_time_shift(domain_values)
 
         # Update Container and return
         updates: list[tuple[str, Tensor]] = [
@@ -107,16 +114,6 @@ class SelectFrameRange(ThermoTransform):
             updates.append(("/MetaData/ExcitationSignal", excitation_signal))
         container.update_datasets(*updates)
         return container
-
-
-def _maybe_zero_base_domain(container: DataContainer, domain_values: Tensor) -> Tensor:
-    """Zero-base domain values for time-domain data only.
-
-    Frequency-domain axes must keep absolute values (e.g. Hz after PPT).
-    """
-    if container.get_unit("/MetaData/DomainValues").quantity == "time":
-        return domain_values - domain_values[0]
-    return domain_values
 
 
 class NonUniformSampling(ThermoTransform):

--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -2,9 +2,11 @@ from collections.abc import Sequence
 from typing import Literal
 
 import torch
+from torch import Tensor
 
 from ..data import DataContainer
 from .base import ThermoTransform
+from .utils import _get_optional_dataset
 
 
 class SelectFrames(ThermoTransform):
@@ -21,9 +23,8 @@ class SelectFrames(ThermoTransform):
 
     def forward(self, container: DataContainer) -> DataContainer:
         # Extract Datasets
-        tdata, domain_values, excitation_signal = container.get_datasets(
-            "/Data/Tdata", "/MetaData/DomainValues", "/MetaData/ExcitationSignal"
-        )
+        tdata, domain_values = container.get_datasets("/Data/Tdata", "/MetaData/DomainValues")
+        has_signal, excitation_signal = _get_optional_dataset(container, "/MetaData/ExcitationSignal")
 
         # Check if frame_indices are valid
         if any(idx < 0 or idx >= tdata.shape[-1] for idx in self.frame_indices):
@@ -36,18 +37,23 @@ class SelectFrames(ThermoTransform):
         # Select Frames
         tdata = tdata[..., self.frame_indices]
         domain_values = domain_values[..., self.frame_indices]
-        excitation_signal = excitation_signal[..., self.frame_indices]
+        if has_signal:
+            assert excitation_signal is not None
+            excitation_signal = excitation_signal[..., self.frame_indices]
 
         # Fix time shift in domain values by subtracting the first time step
-        domain_values = domain_values - domain_values[0]
+        domain_values = _maybe_zero_base_domain(container, domain_values)
 
         # Update Container and return
         # pylint: disable=duplicate-code
-        container.update_datasets(
+        updates: list[tuple[str, Tensor]] = [
             ("/Data/Tdata", tdata),
             ("/MetaData/DomainValues", domain_values),
-            ("/MetaData/ExcitationSignal", excitation_signal),
-        )
+        ]
+        if has_signal:
+            assert excitation_signal is not None
+            updates.append(("/MetaData/ExcitationSignal", excitation_signal))
+        container.update_datasets(*updates)
         # pylint: enable=duplicate-code
         return container
 
@@ -69,9 +75,8 @@ class SelectFrameRange(ThermoTransform):
 
     def forward(self, container: DataContainer) -> DataContainer:
         # Extract Datasets
-        tdata, domain_values, excitation_signal = container.get_datasets(
-            "/Data/Tdata", "/MetaData/DomainValues", "/MetaData/ExcitationSignal"
-        )
+        tdata, domain_values = container.get_datasets("/Data/Tdata", "/MetaData/DomainValues")
+        has_signal, excitation_signal = _get_optional_dataset(container, "/MetaData/ExcitationSignal")
 
         # Check if frame range is valid
         if self.start is not None and (self.start < 0 or self.start >= tdata.shape[-1]):
@@ -89,18 +94,33 @@ class SelectFrameRange(ThermoTransform):
         end = self.end + 1 if self.end is not None else tdata.shape[-1]
         tdata = tdata[..., start:end]
         domain_values = domain_values[..., start:end]
-        excitation_signal = excitation_signal[..., start:end]
+        if has_signal:
+            assert excitation_signal is not None
+            excitation_signal = excitation_signal[..., start:end]
 
         # Fix time shift in domain values by subtracting the first time step
-        domain_values = domain_values - domain_values[0]
+        domain_values = _maybe_zero_base_domain(container, domain_values)
 
         # Update Container and return
-        container.update_datasets(
+        updates: list[tuple[str, Tensor]] = [
             ("/Data/Tdata", tdata),
             ("/MetaData/DomainValues", domain_values),
-            ("/MetaData/ExcitationSignal", excitation_signal),
-        )
+        ]
+        if has_signal:
+            assert excitation_signal is not None
+            updates.append(("/MetaData/ExcitationSignal", excitation_signal))
+        container.update_datasets(*updates)
         return container
+
+
+def _maybe_zero_base_domain(container: DataContainer, domain_values: Tensor) -> Tensor:
+    """Zero-base domain values for time-domain data only.
+
+    Frequency-domain axes must keep absolute values (e.g. Hz after PPT).
+    """
+    if container.get_unit("/MetaData/DomainValues").quantity == "time":
+        return domain_values - domain_values[0]
+    return domain_values
 
 
 class NonUniformSampling(ThermoTransform):

--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -42,7 +42,7 @@ class SelectFrames(ThermoTransform):
         # Select Frames
         tdata = tdata[..., self.frame_indices]
         domain_values = domain_values[..., self.frame_indices]
-        if has_excitation_signal and excitation_signal:
+        if has_excitation_signal and excitation_signal is not None:
             excitation_signal = excitation_signal[..., self.frame_indices]
 
         # Fix time shift in domain values by subtracting the first time step if we are in time domain
@@ -55,7 +55,7 @@ class SelectFrames(ThermoTransform):
             ("/Data/Tdata", tdata),
             ("/MetaData/DomainValues", domain_values),
         ]
-        if has_excitation_signal and excitation_signal:
+        if has_excitation_signal and excitation_signal is not None:
             updates.append(("/MetaData/ExcitationSignal", excitation_signal))
         container.update_datasets(*updates)
         # pylint: enable=duplicate-code
@@ -98,7 +98,7 @@ class SelectFrameRange(ThermoTransform):
         end = self.end + 1 if self.end is not None else tdata.shape[-1]
         tdata = tdata[..., start:end]
         domain_values = domain_values[..., start:end]
-        if has_excitation_signal and excitation_signal:
+        if has_excitation_signal and excitation_signal is not None:
             excitation_signal = excitation_signal[..., start:end]
 
         # Fix time shift in domain values by subtracting the first time step if we are in time domain
@@ -110,7 +110,7 @@ class SelectFrameRange(ThermoTransform):
             ("/Data/Tdata", tdata),
             ("/MetaData/DomainValues", domain_values),
         ]
-        if has_excitation_signal and excitation_signal:
+        if has_excitation_signal and excitation_signal is not None:
             updates.append(("/MetaData/ExcitationSignal", excitation_signal))
         container.update_datasets(*updates)
         return container

--- a/src/pythermondt/transforms/sampling.py
+++ b/src/pythermondt/transforms/sampling.py
@@ -24,7 +24,7 @@ class SelectFrames(ThermoTransform):
     def forward(self, container: DataContainer) -> DataContainer:
         # Extract Datasets
         tdata, domain_values = container.get_datasets("/Data/Tdata", "/MetaData/DomainValues")
-        has_signal, excitation_signal = _get_optional_dataset(container, "/MetaData/ExcitationSignal")
+        has_excitation_signal, excitation_signal = _get_optional_dataset(container, "/MetaData/ExcitationSignal")
 
         # Check if frame_indices are valid
         if any(idx < 0 or idx >= tdata.shape[-1] for idx in self.frame_indices):
@@ -37,8 +37,7 @@ class SelectFrames(ThermoTransform):
         # Select Frames
         tdata = tdata[..., self.frame_indices]
         domain_values = domain_values[..., self.frame_indices]
-        if has_signal:
-            assert excitation_signal is not None
+        if has_excitation_signal and excitation_signal:
             excitation_signal = excitation_signal[..., self.frame_indices]
 
         # Fix time shift in domain values by subtracting the first time step
@@ -50,8 +49,7 @@ class SelectFrames(ThermoTransform):
             ("/Data/Tdata", tdata),
             ("/MetaData/DomainValues", domain_values),
         ]
-        if has_signal:
-            assert excitation_signal is not None
+        if has_excitation_signal and excitation_signal:
             updates.append(("/MetaData/ExcitationSignal", excitation_signal))
         container.update_datasets(*updates)
         # pylint: enable=duplicate-code
@@ -76,7 +74,7 @@ class SelectFrameRange(ThermoTransform):
     def forward(self, container: DataContainer) -> DataContainer:
         # Extract Datasets
         tdata, domain_values = container.get_datasets("/Data/Tdata", "/MetaData/DomainValues")
-        has_signal, excitation_signal = _get_optional_dataset(container, "/MetaData/ExcitationSignal")
+        has_excitation_signal, excitation_signal = _get_optional_dataset(container, "/MetaData/ExcitationSignal")
 
         # Check if frame range is valid
         if self.start is not None and (self.start < 0 or self.start >= tdata.shape[-1]):
@@ -94,8 +92,7 @@ class SelectFrameRange(ThermoTransform):
         end = self.end + 1 if self.end is not None else tdata.shape[-1]
         tdata = tdata[..., start:end]
         domain_values = domain_values[..., start:end]
-        if has_signal:
-            assert excitation_signal is not None
+        if has_excitation_signal and excitation_signal:
             excitation_signal = excitation_signal[..., start:end]
 
         # Fix time shift in domain values by subtracting the first time step
@@ -106,8 +103,7 @@ class SelectFrameRange(ThermoTransform):
             ("/Data/Tdata", tdata),
             ("/MetaData/DomainValues", domain_values),
         ]
-        if has_signal:
-            assert excitation_signal is not None
+        if has_excitation_signal and excitation_signal:
             updates.append(("/MetaData/ExcitationSignal", excitation_signal))
         container.update_datasets(*updates)
         return container

--- a/tests/transforms/conftest.py
+++ b/tests/transforms/conftest.py
@@ -1,0 +1,58 @@
+"""Shared fixtures for transform tests."""
+
+import pytest
+import torch
+
+from pythermondt.data import ThermoContainer
+from pythermondt.data.units import second
+
+from .utils import ThermoSequenceFactory
+
+
+@pytest.fixture
+def thermo_sequence() -> ThermoSequenceFactory:
+    """Factory for a minimal time-domain ThermoContainer.
+
+    Builds ``Tdata`` (H x W x T), uniformly spaced ``DomainValues``, and optionally
+    an ``ExcitationSignal``. Suitable as a base for sampling and frequency transforms.
+
+    Example:
+        container = thermo_sequence(n_frames=32)
+        container = thermo_sequence(n_frames=20, excitation_signal=False)
+        container = thermo_sequence(n_frames=20, excitation_signal=custom_signal)
+    """
+
+    def _factory(
+        n_frames: int = 32,
+        *,
+        height: int = 4,
+        width: int = 5,
+        excitation_signal: bool | torch.Tensor = True,
+        dt: float = 0.01,
+        seed: int = 0,
+    ) -> ThermoContainer:
+        container = ThermoContainer()
+        generator = torch.Generator().manual_seed(seed)
+        tdata = torch.randn(height, width, n_frames, dtype=torch.float64, generator=generator)
+        domain_values = torch.arange(n_frames, dtype=torch.float64) * dt
+
+        container.update_dataset("/Data/Tdata", tdata)
+        container.update_dataset("/MetaData/DomainValues", domain_values)
+        container.update_unit("/MetaData/DomainValues", second)
+
+        if excitation_signal is False:
+            container.remove_dataset("/MetaData/ExcitationSignal")
+        elif excitation_signal is True:
+            signal = torch.zeros(n_frames, dtype=torch.float64)
+            signal[:3] = 1.0
+            container.update_dataset("/MetaData/ExcitationSignal", signal)
+        else:
+            if excitation_signal.shape[-1] != n_frames:
+                raise ValueError(
+                    f"excitation_signal length {excitation_signal.shape[-1]} does not match n_frames={n_frames}."
+                )
+            container.update_dataset("/MetaData/ExcitationSignal", excitation_signal.to(dtype=torch.float64))
+
+        return container
+
+    return _factory

--- a/tests/transforms/test_sampling.py
+++ b/tests/transforms/test_sampling.py
@@ -1,0 +1,107 @@
+"""Tests for sampling transforms (SelectFrames, SelectFrameRange, ...)."""
+
+import pytest
+import torch
+
+from pythermondt.data.units import hertz
+from pythermondt.transforms import Compose, ExtractPhase, PulsePhaseThermography, SelectFrameRange, SelectFrames
+
+from .utils import ThermoSequenceFactory, has_dataset
+
+EXCITATION_SIGNAL = "/MetaData/ExcitationSignal"
+TDATA = "/Data/Tdata"
+DOMAIN_VALUES = "/MetaData/DomainValues"
+
+
+@pytest.mark.parametrize(
+    ("transform", "n_frames", "expected_len"),
+    [
+        (SelectFrameRange(start=2, end=10), 20, 9),
+        (SelectFrames([0, 5, 10]), 20, 3),
+    ],
+    ids=["frame_range", "frames"],
+)
+def test_select_without_excitation_signal(
+    thermo_sequence: ThermoSequenceFactory,
+    transform: SelectFrameRange | SelectFrames,
+    n_frames: int,
+    expected_len: int,
+):
+    """Select* must work when ExcitationSignal is absent."""
+    container = thermo_sequence(n_frames=n_frames, excitation_signal=False)
+
+    result = transform(container)
+
+    assert result.get_dataset(TDATA).shape[-1] == expected_len
+    assert result.get_dataset(DOMAIN_VALUES).shape[-1] == expected_len
+    assert not has_dataset(result, EXCITATION_SIGNAL)
+
+
+@pytest.mark.parametrize(
+    ("transform", "n_frames", "expected_signal"),
+    [
+        (SelectFrames([0, 5, 10]), 20, torch.tensor([1.0, 0.0, 0.0], dtype=torch.float64)),
+        (SelectFrameRange(start=0, end=4), 20, torch.tensor([1.0, 1.0, 1.0, 0.0, 0.0], dtype=torch.float64)),
+    ],
+    ids=["frames", "frame_range"],
+)
+def test_select_keeps_excitation_signal_in_sync(
+    thermo_sequence: ThermoSequenceFactory,
+    transform: SelectFrameRange | SelectFrames,
+    n_frames: int,
+    expected_signal: torch.Tensor,
+):
+    """When present, ExcitationSignal is sliced together with Tdata."""
+    container = thermo_sequence(n_frames=n_frames, excitation_signal=True)
+
+    result = transform(container)
+
+    signal = result.get_dataset(EXCITATION_SIGNAL)
+    assert signal.shape[-1] == expected_signal.shape[-1]
+    assert result.get_dataset(TDATA).shape[-1] == expected_signal.shape[-1]
+    assert torch.equal(signal, expected_signal)
+
+
+def test_select_frame_range_zero_bases_time_domain(thermo_sequence: ThermoSequenceFactory):
+    """Time-domain DomainValues are zero-based after a crop that does not start at 0."""
+    container = thermo_sequence(n_frames=20, excitation_signal=False, dt=0.01)
+
+    result = SelectFrameRange(start=2, end=10)(container)
+
+    domain = result.get_dataset(DOMAIN_VALUES)
+    assert torch.allclose(domain[0], torch.tensor(0.0, dtype=domain.dtype))
+    assert torch.allclose(domain[1] - domain[0], torch.tensor(0.01, dtype=domain.dtype))
+
+
+def test_select_frame_range_keeps_absolute_frequency_domain(thermo_sequence: ThermoSequenceFactory):
+    """Frequency-domain DomainValues keep absolute Hz (no zero-base after PPT)."""
+    container = PulsePhaseThermography()(thermo_sequence(n_frames=64))
+    freqs_before = container.get_dataset(DOMAIN_VALUES).clone()
+    assert container.get_unit(DOMAIN_VALUES) == hertz
+
+    start, end = 5, 12
+    result = SelectFrameRange(start=start, end=end)(container)
+
+    freqs_after = result.get_dataset(DOMAIN_VALUES)
+    assert torch.allclose(freqs_after, freqs_before[start : end + 1])
+    assert torch.allclose(freqs_after[0], freqs_before[start])
+
+
+def test_select_frame_range_after_ppt_and_extract_phase(thermo_sequence: ThermoSequenceFactory):
+    """Regression: PPT drops ExcitationSignal; SelectFrameRange must still run.
+
+    https://github.com/voidsy-gmbh/pyThermoNDT/issues/458
+    """
+    end = 32
+    result = Compose(
+        [
+            PulsePhaseThermography(),
+            ExtractPhase(),
+            SelectFrameRange(end=end),
+        ]
+    )(thermo_sequence(n_frames=64))
+
+    n_keep = end + 1  # end is inclusive
+    assert result.get_dataset(TDATA).shape[-1] == n_keep
+    assert result.get_dataset(DOMAIN_VALUES).shape[-1] == n_keep
+    assert not has_dataset(result, EXCITATION_SIGNAL)

--- a/tests/transforms/utils.py
+++ b/tests/transforms/utils.py
@@ -1,0 +1,12 @@
+"""Helpers for transform tests."""
+
+from collections.abc import Callable
+
+from pythermondt.data import DataContainer, ThermoContainer
+
+ThermoSequenceFactory = Callable[..., ThermoContainer]
+
+
+def has_dataset(container: DataContainer, path: str) -> bool:
+    """Return whether ``path`` is present as a dataset node."""
+    return path in container.get_all_dataset_paths()


### PR DESCRIPTION
- Fix SelectFrames and SelectFrameRange failing with an error when the container lacks an ExcitationSignal dataset
- Conditionally skip ExcitationSignal indexing, container updates, and UI additions only when the dataset is present and non-empty
- Gate time-shift zero-basing on whether DomainValues represent time (via `container.get_unit`), so frequency-domain values remain absolute
- Add tests for both SelectFrame and SelectFrameRange covering: missing ExcitationSignal, existing ExcitationSignal sync, time-domain zero-basing, frequency-domain non-zero-basing, and a regression case where PulsePhaseThermography followed by ExtractPhase and SelectFrameRange
- Add shared test fixtures for building ThermoContainers with optional ExcitationSignal
- Add `has_dataset` and `ThermoSequenceFactory` helpers to test utilities

Closes #458.